### PR TITLE
Add deleteUnusedOutput api

### DIFF
--- a/TestResultSummaryService/routes/deleteUnusedOutput.js
+++ b/TestResultSummaryService/routes/deleteUnusedOutput.js
@@ -1,0 +1,31 @@
+const { TestResultsDB, OutputDB } = require( '../Database' );
+
+/*
+ * This API deletes all orphan outputs that do not have reference in 
+ * testResults collection. That is, _id output does not match any
+ * testOutputId or buildOutputId in testResults.
+ * 
+ * This API should only be used for DB clean up purpose only.
+ */
+module.exports = async ( req, res ) => {
+    const results = await ( new TestResultsDB().getData( {} ).toArray() );
+
+    // concat all testOutputId and buildOutputId into an array and remove null
+    const outputs = [].concat( ...results.map( result => {
+        let res = [];
+        if ( result.tests ) {
+            res = result.tests.map( test => {
+                return test.testOutputId;
+            } );
+        }
+        if ( result.buildOutputId ) {
+            res.push( result.buildOutputId );
+        }
+        return res;
+    } ) ).filter( v => !!v );
+
+    // delete all outputs that are not in outputs array
+    const response = await new OutputDB().deleteMany( { '_id': { '$nin': outputs } } );
+
+    res.json( response );
+}

--- a/TestResultSummaryService/routes/index.js
+++ b/TestResultSummaryService/routes/index.js
@@ -5,6 +5,7 @@ app.get( '/compareTests', wrap( require( "./compareTests" ) ) );
 app.get( '/deleteBuildListById', wrap( require( "./deleteBuildListById" ) ) );
 app.get( '/deleteBuildsAndChildrenByFields', wrap( require( "./deleteBuildsAndChildrenByFields" ) ) );
 app.get( '/deleteCollection', wrap( require( "./deleteCollection" ) ) );
+app.get( '/deleteUnusedOutput', wrap( require( "./deleteUnusedOutput" ) ) );
 app.get( '/getAllTestsWithHistory', wrap( require( "./getAllTestsWithHistory" ) ) );
 app.get( '/getBuildHistory', wrap( require( "./getBuildHistory" ) ) );
 app.get( '/getBuildList', wrap( require( "./getBuildList" ) ) );


### PR DESCRIPTION
Orphan outputs maybe created in output. deleteUnusedOutput is
created to delete these orphan outputs. This API is for DB clean
up purpose only.

Signed-off-by: lanxia <lan_xia@ca.ibm.com>