### PR TITLE
Update Build Server URL to show only the Good Builds

### DIFF
--- a/PerfNext/app/apis/builds.js
+++ b/PerfNext/app/apis/builds.js
@@ -16,7 +16,7 @@ module.exports = function(app) {
     	var product = req.query.product;
     	
 		var getOptions = {
-				url: global.APP_DATA.builds_server_url + product + "/?full=1",
+				url: global.APP_DATA.builds_server_url + product,
 				auth: {
 					'user': global.perffarmUsername,
 					'pass': global.perffarmEspressoPwd,


### PR DESCRIPTION
• Updated the Espresso server URL so that it only shows the good builds. Due to the new Espresso format and the requirement to use W3 id instead of CMVC id, Perffarm W3 id can see all the good and bad builds but can only download the good builds. As a result, earlier PerfNext could show you a bad Espresso SDK but the Jenkins build would fail since we wouldn't be able to download that bad SDK.

Signed-off-by: Piyush <piyush@ca.ibm.com>