### PR TITLE
Enable interleaved runs through master pipeline

### DIFF
--- a/PerfNext/public/lib/js/util.js
+++ b/PerfNext/public/lib/js/util.js
@@ -928,20 +928,17 @@ function submitJobHelper(key, isBaseline) {
     
     var benchmarkName = selectedBenchmarks[key].name + '-' + selectedBenchmarks[key].variant;
     
-    if (isBaseline)
-    	{
-    	benchmarkName += ' (Baseline Build)';
-    	}
-    else
-    	{
-    	benchmarkName += ' (Test Build)';
-    	}
-    
     console.log("submitJob() selectedBenchmarks[key].name: "+selectedBenchmarks[key].name);
     console.log("submitJob() selectedBenchmarks[key].variant: "+selectedBenchmarks[key].variant);
 
 	var requestAPI = "/api/benchengine/submit?machine=" + $('#machine-selection').val();
-	var jobData = parseJob(selectedBenchmarks[key], isBaseline);
+	var jobData = parseJob(selectedBenchmarks[key], false);
+	
+    // If interleaving add the baseline job information to the xml file
+	if (isBaseline) {
+    	var baselineData = parseJob(selectedBenchmarks[key], true);
+    	jobData = jobData + baselineData;
+    }
 
 	/* TODO: Need to add '#notification' to the html page since it's not there currently, hence 
 	 * we don't get the result whether we were able to submit the job successfully or not. */
@@ -1012,7 +1009,7 @@ function submitJob() {
 		console.log('submitJob(): Inside ajaxStart');			
 	});
 	
-	$('#submit-console-output').html('Submitting Jobs to Jenkins. Please wait for Jenkin Build URLs to be generated...');
+	$('#submit-console-output').html('Submitting Jobs to Jenkins. Please wait (up to 5 seconds) for Jenkins Build URLs to be generated...');
 	
 	for (var key in selectedBenchmarks)
 	{
@@ -1021,7 +1018,6 @@ function submitJob() {
 			if (document.getElementById('RunBaseline').checked)
 				{
 				console.log('util.js: RunBaseline is checked');
-				submitJobHelper(key, false);
 				submitJobHelper(key, true);
 				}
 			else


### PR DESCRIPTION
Changes made to script parser to allow interleaved runs by using a master pipeline connected to children pipelines. Each benchmark iteration will now run on a separate job on the child pipeline.

Interleaved runs will ping pong between test and baseline builds.

Closes #24 