### PR TITLE
Pat - API 

### DIFF
--- a/TestResultSummaryService/routes/getBuildHistory.js
+++ b/TestResultSummaryService/routes/getBuildHistory.js
@@ -1,9 +1,22 @@
 const { TestResultsDB, ObjectID } = require( '../Database' );
+
+function _cleanParams(query) {
+  for (let key in query) {
+    if (Array.isArray(query[key])) {
+      query[key] = {
+        $in: query[key]
+      }
+    }
+  }
+};
+
 module.exports = async ( req, res ) => {
   const { limit = 5, asc = false, ...query } = req.query;
   const sortData = {
     timestamp: asc ? 1 : -1
   };
+
+  _cleanParams(query);
 
   if ( query.parentId ) query.parentId = new ObjectID( query.parentId );
   const db = new TestResultsDB();


### PR DESCRIPTION
Change to allow multiple build names in getBuildHistory call 

Validation: 
Called `http://localhost:3000/api/getBuildHistory?type=Perf&buildName=Daily-ODM&buildName=Daily-ODM-Linux-PPCLE64&buildName=Daily-ODM-openJ9&status=Done&limit=100&asc` and for the following response: 
