### PR TITLE
API for getTotals ( query )

### DIFF
--- a/TestResultSummaryService/routes/getTotals.js
+++ b/TestResultSummaryService/routes/getTotals.js
@@ -1,0 +1,8 @@
+const { TestResultsDB, ObjectID } = require('../Database');
+
+module.exports = async (req, res) => {
+  const testResultsDB = new TestResultsDB();
+  console.log(req.query);
+  const result = await testResultsDB.getTotals(req.query);
+  res.send(result);
+}

--- a/TestResultSummaryService/routes/index.js
+++ b/TestResultSummaryService/routes/index.js
@@ -23,6 +23,7 @@ app.get( '/getTestById', wrap( require( "./getTestById" ) ) );
 app.get( '/getTestBySearch', wrap( require( "./getTestBySearch" ) ) );
 app.get( '/getTestPerPlatform', wrap( require( "./getTestPerPlatform" ) ) );
 app.get( '/getTopLevelBuildNames', wrap( require( "./getTopLevelBuildNames" ) ) );
+app.get( '/getTotals', wrap( require( "./getTotals" ) ) );
 app.get( '/populateDB', wrap( require( "./populateDB" ) ) );
 
 


### PR DESCRIPTION
- query can contain url, buildName, buildNum, level, group, platform and
impl
- this API returns aggregated numbers of total, executed, passed, failed
and skipped tests based on the sdkID
- sdkID is a combo of Jenkins url, buildName, buildNum for now. It
should be shas once we have the info stored
- level, group, platform are optional params
- impl needs to be added once we have impl info stored


Issue: #43

Signed-off-by: lanxia <lan_xia@ca.ibm.com>