### PR TITLE
Updated Perf Test display with parent and children builds separately

### DIFF
--- a/test-result-summary-client/src/Build/AllTestsInfo.jsx
+++ b/test-result-summary-client/src/Build/AllTestsInfo.jsx
@@ -16,8 +16,8 @@ export default class Build extends Component {
     }
 
     async updateData() {
-        const { buildId } = getParams( this.props.location.search );
-        const fetchBuild = await fetch( `/api/getAllTestsWithHistory?buildId=${buildId}&limit=5 `, {
+        const { buildId, limit } = getParams( this.props.location.search );
+        const fetchBuild = await fetch( `/api/getAllTestsWithHistory?buildId=${buildId}&limit=${limit}`, {
             method: 'get'
         } );
         const builds = await fetchBuild.json();

--- a/test-result-summary-client/src/Build/BuildTable.jsx
+++ b/test-result-summary-client/src/Build/BuildTable.jsx
@@ -49,7 +49,11 @@ export default class TestTable extends Component {
                         style={{ color: resultColor }}> {value.buildName} </Link>;
                 }
             }
-            return <Link to={{ pathname: '/allTestsInfo', search: params( { buildId: value._id } ) }}
+            let limit = 5;
+            if ( value.type === "Perf") {
+                limit = 1;
+            }
+            return <Link to={{ pathname: '/allTestsInfo', search: params( { buildId: value._id, limit: limit } ) }}
                 style={{ color: resultColor }}> {value.buildName} </Link>;
         };
 

--- a/test-result-summary-client/src/Build/TopLevelBuilds.jsx
+++ b/test-result-summary-client/src/Build/TopLevelBuilds.jsx
@@ -85,9 +85,8 @@ export default class TopLevelBuilds extends Component {
                         }
                     } else {
                         return <div>
-                            <Link to={{ pathname: '/output/all', search: params({ id: value._id }) }}
-                                style={{ color: result === "SUCCESS" ? "#2cbe4e" : (result === "FAILURE" ? "#f50" : "#DAA520") }}>
-                                Build #{value.buildNum}
+                            <Link to={{ pathname: '/buildDetail', search: params( { parentId: value._id } ) }}
+                                style={{ color: result === "SUCCESS" ? "#2cbe4e" : ( result === "FAILURE" ? "#f50" : "#DAA520" ) }}> Build #{value.buildNum}
                             </Link>
                         </div>;
                     }


### PR DESCRIPTION
    - Perf Test should display the parent builds in the first layer, by clicking each parent build's link would give information of all its child builds.

Issue: #24