### PR TITLE
Store last 12M of output

### DIFF
--- a/test-result-summary-client/src/Build/AllTestsInfo.jsx
+++ b/test-result-summary-client/src/Build/AllTestsInfo.jsx
@@ -34,7 +34,12 @@ export default class Build extends Component {
                 ret.action = {
                     testId: test._id,
                 };
-                builds.forEach(( { tests, parentNum }, i ) => {
+                builds.forEach(({ tests, parentNum }, i) => {
+                    if (!tests) {
+                        return ret[i] = {
+                            testResult: 'N/A',
+                        };
+                    }
                     const found = tests.find( t => t.testName === test.testName );
                     if ( found ) {
                         const { testResult, _id } = found


### PR DESCRIPTION
- Due to 16M document size limit, only store last ~12M output
- if tests obj is empty, display N/A

Fixed: #57

Signed-off-by: lanxia <lan_xia@ca.ibm.com>