### PR TITLE
Aggregated information added

### DIFF
--- a/TestResultSummaryService/BuildProcessor.js
+++ b/TestResultSummaryService/BuildProcessor.js
@@ -6,6 +6,7 @@ const ParentBuild = require(`./parsers/ParentBuild`);
 const ObjectID = require('mongodb').ObjectID;
 const { OutputDB } = require('./Database');
 const { logger } = require('./Utils');
+const DataManagerPerf = require('./perf/DataManagerPerf');
 
 class BuildProcessor {
     async execute(task) {
@@ -91,7 +92,8 @@ class BuildProcessor {
                     task.buildUrl = buildInfo.url;
                     task.buildDuration = buildInfo.duration;
                     task.buildResult = buildInfo.result;
-                    task.status = "Done";
+                    // update "Perf" builds and their descendant builds with aggregated info.
+                    await new DataManagerPerf().updateBuildWithAggResult(task);
 
                     output = await jenkinsInfo.getBuildOutput(task.url, task.buildName, task.buildNum);
                     task.output = output;

--- a/TestResultSummaryService/perf/BenchmarkMathCalculation.js
+++ b/TestResultSummaryService/perf/BenchmarkMathCalculation.js
@@ -1,4 +1,4 @@
-class BenchmarkMath {
+class BenchmarkMathCalculation {
 
     // Taken from Perffarm/perfsite/benchmarks.php
     /*
@@ -141,4 +141,4 @@ class BenchmarkMath {
         return v;
     }
 }
-export default BenchmarkMath;
+module.exports = BenchmarkMathCalculation;

--- a/TestResultSummaryService/perf/DataManagerPerf.js
+++ b/TestResultSummaryService/perf/DataManagerPerf.js
@@ -1,0 +1,93 @@
+const { TestResultsDB, OutputDB } = require( '../Database' );
+const ObjectID = require( 'mongodb' ).ObjectID;
+const Parsers = require( `../parsers/` );
+const DefaultParser = require( `../parsers/Default` );
+const { logger } = require( '../Utils' );
+const BenchmarkMath = require( './BenchmarkMathCalculation' );
+const math = require('mathjs');
+
+class DataManagerPerf {
+    async updateBuildWithAggResult ( task ) {
+        if ( task.type === "Perf") {
+            if( task.aggregateInfo === undefined ) {
+                let allDone = true;
+                const parentId = task._id;
+                let testResults = new TestResultsDB();
+                const childBuildList = await testResults.getData({parentId}).toArray();
+                if ( childBuildList && childBuildList.length > 0 ) {
+                    for ( let i = 0; i < childBuildList.length; i++ ) {
+                        if ( childBuildList[i].status === "NotDone" ) {
+                            allDone = false;
+                        }
+                    }
+                } else {
+                    allDone = false;
+                }
+                if ( allDone ) {
+                    await this.updateBuild(task);
+                    task.status = "Done";
+                }
+            } else {
+                task.status = "Done";
+            }
+        } else {
+            task.status = "Done";
+        }
+    }
+    async updateBuild( task ) {
+        logger.debug("Update Aggregate Info", task._id, task.buildName, task.buildNum);
+        let testResults = new TestResultsDB();
+        let parentId = task._id;
+        let childBuildList = await testResults.getData({parentId}).toArray();
+        if(childBuildList && childBuildList.length > 0){
+            const parentAggregationStructure = [];
+            let BenchmarkName, BenchmarkVariant, BenchmarkProduct;
+            const childrenAggData = [];
+            const metricsCollection = {};
+            for ( let j = 0; j < childBuildList.length; j++ ) {
+                if (childBuildList[j].aggregateInfo && childBuildList[j].aggregateInfo.length > 0) {
+                    for (let k = 0 ; k < childBuildList[j].aggregateInfo.length; k++){
+                        BenchmarkName = childBuildList[j].aggregateInfo[k].benchmarkName;
+                        BenchmarkVariant = childBuildList[j].aggregateInfo[k].benchmarkVariant;
+                        BenchmarkProduct = childBuildList[j].aggregateInfo[k].benchmarkProduct;
+                        if( childBuildList[j].aggregateInfo[k] && childBuildList[j].aggregateInfo[k]["metrics"] && childBuildList[j].aggregateInfo[k]["metrics"].length > 0 ){
+                            for ( let l = 0 ; l < childBuildList[j].aggregateInfo[k]["metrics"].length; l++ ){
+                                const childMetricName = childBuildList[j].aggregateInfo[k]["metrics"][l]["name"];
+                                const childMean = childBuildList[j].aggregateInfo[k]["metrics"][l]["value"]["mean"];
+                                if ( !metricsCollection[childMetricName] ){
+                                    metricsCollection[childMetricName] = [childMean];
+                                } else {
+                                    metricsCollection[childMetricName].push(childMean);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            Object.keys( metricsCollection ).forEach( function(key) {
+                const meanMetric = math.mean(metricsCollection[key]);
+                const maxMetric = math.max(metricsCollection[key]);
+                const minMetric = math.min(metricsCollection[key]);
+                const medianMetric = math.median(metricsCollection[key]);
+                const stddevMetric = math.std(metricsCollection[key]);
+                const ciMetric = BenchmarkMath.confidence_interval(metricsCollection[key]);
+                childrenAggData.push({name: key, value: { mean: meanMetric, max: maxMetric, min: minMetric, median: medianMetric, stddev: stddevMetric, CI: ciMetric, iteration: metricsCollection[key].length } });
+            })
+            parentAggregationStructure.push({
+                benchmarkName: BenchmarkName,
+                benchmarkVariant: BenchmarkVariant,
+                benchmarkProduct: BenchmarkProduct,
+                metrics: childrenAggData
+            });
+            const { _id, ...value } = task;
+            const criteria = { _id: new ObjectID( _id ) };
+            const update = {
+                ...value
+            };
+            update.aggregateInfo = parentAggregationStructure;
+            const result = await testResults.update( criteria, { $set: update } );
+        }
+    }
+}
+
+module.exports = DataManagerPerf;

--- a/test-result-summary-client/src/PerfCompare/lib/JenkinsRunJSON.js
+++ b/test-result-summary-client/src/PerfCompare/lib/JenkinsRunJSON.js
@@ -1,5 +1,3 @@
-import math from 'mathjs';
-import BenchmarkMath from './BenchmarkMath';
 
 export default class JenkinsRunJSON {
     constructor(runJSON) {
@@ -13,11 +11,10 @@ export default class JenkinsRunJSON {
         let curVariantObject = null;
         let curVariantObjectId = null;
 
-        if (this.runJSON.testInfo[0].tests !== undefined) {
-            for (let k = 0; k < this.runJSON.testInfo[0].tests.length; k++) {
-
-                if (this.runJSON.testInfo[0].tests[k].benchmarkName && this.runJSON.testInfo[0].tests[k].benchmarkVariant) {
-                    curVariantObjectId = this.runJSON.testInfo[0].tests[k].benchmarkName + "!@#$%DELIMIT%$#@!" + this.runJSON.testInfo[0].tests[k].benchmarkVariant;
+        if (this.runJSON.testInfo[0].aggregateInfo !== undefined) {
+            for (let k = 0; k < this.runJSON.testInfo[0].aggregateInfo.length; k++) {
+                if (this.runJSON.testInfo[0].aggregateInfo[k].benchmarkName && this.runJSON.testInfo[0].aggregateInfo[k].benchmarkVariant) {
+                    curVariantObjectId = this.runJSON.testInfo[0].aggregateInfo[k].benchmarkName + "!@#$%DELIMIT%$#@!" + this.runJSON.testInfo[0].aggregateInfo[k].benchmarkVariant;
                 } else {
                     // invalid benchmark name and/or variant. Skipping it.
                     continue;
@@ -26,31 +23,30 @@ export default class JenkinsRunJSON {
                 // new variant
                 if (parsedVariantsCommon[curVariantObjectId] === undefined) {
                     parsedVariantsCommon[curVariantObjectId] = {
-                        product: (this.runJSON.testInfo[0].tests[k].benchmarkProduct === undefined) ? null : this.runJSON.testInfo[0].tests[k].benchmarkProduct,
-                        result: (this.runJSON.testInfo[0].tests[k].testResult === undefined) ? null : this.runJSON.testInfo[0].tests[k].testResult,
-                        benchmark: (this.runJSON.testInfo[0].tests[k].benchmarkName === undefined) ? null : this.runJSON.testInfo[0].tests[k].benchmarkName,
-                        variant: (this.runJSON.testInfo[0].tests[k].benchmarkVariant === undefined) ? null : this.runJSON.testInfo[0].tests[k].benchmarkVariant,
-                        machine: (this.runJSON.testInfo[0].machine === undefined) ? null : this.runJSON.testInfo[0].machine,
-                        metrics: (this.runJSON.testInfo[0].tests[k].testData.metrics === undefined) ? [] : this.runJSON.testInfo[0].tests[k].testData.metrics
+                        product: (this.runJSON.testInfo[0].aggregateInfo[k].benchmarkProduct === undefined) ? null : this.runJSON.testInfo[0].aggregateInfo[k].benchmarkProduct,
+                        benchmark: (this.runJSON.testInfo[0].aggregateInfo[k].benchmarkName === undefined) ? null : this.runJSON.testInfo[0].aggregateInfo[k].benchmarkName,
+                        variant: (this.runJSON.testInfo[0].aggregateInfo[k].benchmarkVariant === undefined) ? null : this.runJSON.testInfo[0].aggregateInfo[k].benchmarkVariant,
+                        metrics: (this.runJSON.testInfo[0].aggregateInfo[k].metrics === undefined) ? [] : this.runJSON.testInfo[0].aggregateInfo[k].metrics,
+                        testsData: (this.runJSON.testInfo[0].tests === undefined) ? undefined : this.runJSON.testInfo[0].tests[0]["testData"]["metrics"]
                     };
 
                 // variant already exists
                 } else {
                     // loop over the current metrics
-                    for (let x = 0; x < this.runJSON.testInfo[0].tests[k].testData.metrics.length; x++) {
+                    for (let x = 0; x < this.runJSON.testInfo[0].aggregateInfo[k].metrics.length; x++) {
 
                         // loop over existing metrics
-                        for (let y = 0; y < parsedVariantsCommon[curVariantObjectId].metrics.length; y++) {
+                        for (let y = 0; y < parsedVariantsCommon[curVariantObjectId]["metrics"].length; y++) {
 
                             // matching metric found
-                            if (this.runJSON.testInfo[0].tests[k].testData.metrics[x].name === parsedVariantsCommon[curVariantObjectId].metrics[y].name) {
-
+                            if (this.runJSON.testInfo[0].aggregateInfo[k].metrics[x]["name"] === parsedVariantsCommon[curVariantObjectId]["metrics"][y]["name"]) {
+                                  this.parsedVariants.push(parsedVariantsCommon[curVariantObjectId]["metrics"][y]["value"])
                                 // create a metric value array with the existing value as the first element
                                 if (! Array.isArray(parsedVariantsCommon[curVariantObjectId].metrics[y].value)) {
                                     parsedVariantsCommon[curVariantObjectId].metrics[y].value = [parsedVariantsCommon[curVariantObjectId].metrics[y].value];
                                 }
                                 // Concat the metric value arrays
-                                parsedVariantsCommon[curVariantObjectId].metrics[y].value = parsedVariantsCommon[curVariantObjectId].metrics[y].value.concat(this.runJSON.testInfo[0].tests[k].testData.metrics[x].value)
+                                parsedVariantsCommon[curVariantObjectId].metrics[y].value = parsedVariantsCommon[curVariantObjectId].metrics[y].value.concat(this.runJSON.testInfo[0].tests[k].testData.metrics[x]["value"])
                                 break;
                             }
                         }
@@ -65,13 +61,13 @@ export default class JenkinsRunJSON {
             for (let z = 0; z < curVariantObject.metrics.length; z++) {
                 if (Array.isArray(curVariantObject.metrics[z].value)) {
                     try {
-                        curVariantObject.metrics[z]["mean"] = math.mean(curVariantObject.metrics[z].value);
+                        curVariantObject.metrics[z]["mean"] = curVariantObject.metrics[z]["value"]["mean"];
                     } catch(e) {
                         curVariantObject.metrics[z]["mean"] = null;
                     }
 
                     try {
-                        curVariantObject.metrics[z]["ci"] = BenchmarkMath.confidence_interval(curVariantObject.metrics[z].value) * 100;
+                        curVariantObject.metrics[z]["ci"] = curVariantObject.metrics[z]["value"]["CI"] * 100;
                     } catch(e) {
                         curVariantObject.metrics[z]["ci"] = null;
                     }


### PR DESCRIPTION
1. Aggregated information added to Perf type builds in the database, move the Benchmark Math calcualtion from the client side to backend to save the operation time.

2. Modification on the Perf Compare, especially on the raw data displaying.

Issue: #24 #70 #73 AdoptOpenJDK/openjdk-tests#850

Signed-off-by: sophiaxu0424 <xmh1989@my.yorku.ca>