### PR TITLE
Add aggregate information to each node

### DIFF
--- a/TestResultSummaryService/BuildProcessor.js
+++ b/TestResultSummaryService/BuildProcessor.js
@@ -6,6 +6,7 @@ const ParentBuild = require(`./parsers/ParentBuild`);
 const ObjectID = require('mongodb').ObjectID;
 const { TestResultsDB, OutputDB } = require('./Database');
 const { logger } = require('./Utils');
+const DataManagerPerf = require('./perf/DataManagerPerf');
 
 class BuildProcessor {
     async execute(task) {
@@ -108,6 +109,8 @@ class BuildProcessor {
                 const testResultsDB = new TestResultsDB();
                 const childBuilds = await testResultsDB.getData({ parentId: task._id, status: { $ne: "Done" } }).toArray();
                 if (childBuilds.length === 0) {
+                    // update "Perf" builds and their descendant builds with aggregated info.
+                    await new DataManagerPerf().updateBuildWithAggResult(task);
                     await new DataManager().updateBuild({
                         _id: task._id,
                         status: "Done"

--- a/TestResultSummaryService/package.json
+++ b/TestResultSummaryService/package.json
@@ -25,6 +25,7 @@
     "express": "^4.16.4",
     "got": "^9.6.0",
     "jenkins-api": "^0.3.1",
+    "mathjs": "^5.9.0",
     "mongodb": "^2.2.31",
     "request": "^2.88.0",
     "winston": "^2.4.4"

--- a/TestResultSummaryService/perf/BenchmarkMathCalculation.js
+++ b/TestResultSummaryService/perf/BenchmarkMathCalculation.js
@@ -1,0 +1,89 @@
+const math = require('mathjs');
+
+class BenchmarkMathCalculation {
+
+    // Taken from Perffarm/perfsite/benchmarks.php
+    /*
+    * This function calculates the confidence interval of a set
+    * of results. We are limited to testing for 5%
+    * convergence.
+    */
+    static confidence_interval ( scores ) {
+        let scores_sum = 0;
+        scores.forEach((x) => {
+            if (x !== null) {
+                scores_sum += x;
+            }
+        });
+
+        // First get the std deviation and other
+        // useful values as floats.
+        if (scores_sum !== 0) {
+            let stddev = math.std(scores);
+            let count = scores.length;
+            let mean = scores_sum / count;
+
+            // Do the convergence calculations.
+            let ci = stddev * this.t_dist05( count - 1 );
+            ci /= mean;
+            ci /= Math.sqrt(count);
+
+            return ci;
+        } else {
+            return 0;
+        }
+    }
+
+    // Taken from Perffarm/perfsite/benchmarks.php
+    /*
+    * This is a lookup function for the t-distribution.
+    * It is based on the statistical tests code Dave
+    * Siegwart wrote for RAJ.
+    * It only does probability of 0.05.
+    */
+    static t_dist05( N ) {
+
+        // Constants for t-dist calculations.
+        let Student_t_05 = [
+            -1.0,
+            12.706, 4.303, 3.182, 2.776, 2.571,
+            2.447, 2.365, 2.306, 2.262, 2.228,
+
+            2.201, 2.179, 2.160, 2.145, 2.131,
+            2.120, 2.110, 2.101, 2.093, 2.086,
+
+            2.080, 2.074, 2.069, 2.064, 2.060,
+            2.056, 2.052, 2.048, 2.045, 2.042
+        ];
+        let Student_t_05_40    = 2.021;
+        let Student_t_05_60    = 2.000;
+        let Student_t_05_120   = 1.98;
+        let Student_t_05_2000  = 1.96;
+
+        let P = 0.0;
+
+        if (N <= 30) {
+            P = Student_t_05[N];
+        } else if (N <= 40) {
+            P = this.interp(Student_t_05[30], Student_t_05_40, 30, 40, N);
+        } else if (N <= 60) {
+            P = this.interp(Student_t_05_40 , Student_t_05_60, 40, 60, N);
+        } else if (N <= 120) {
+            P = this.interp(Student_t_05_60, Student_t_05_120, 60, 120, N);
+        } else if (N <= 2000) {
+            P = this.interp(Student_t_05_120, Student_t_05_2000, 120, 2000, N);
+        } else {
+            P = Student_t_05_2000;
+        }
+        return P;
+    }
+
+    // Taken from Perffarm/perfsite/benchmarks.php
+    // Support function for t_dist05
+    static interp( a, b, aN, bN, N ) {
+        let mu = (N - aN) / (bN - aN);
+        let v = mu * (b - a) + a;
+        return v;
+    }
+}
+module.exports = BenchmarkMathCalculation;

--- a/TestResultSummaryService/perf/DataManagerPerf.js
+++ b/TestResultSummaryService/perf/DataManagerPerf.js
@@ -1,0 +1,68 @@
+const { TestResultsDB } = require( '../Database' );
+const ObjectID = require( 'mongodb' ).ObjectID;
+const { logger } = require( '../Utils' );
+const BenchmarkMath = require( './BenchmarkMathCalculation' );
+const math = require('mathjs');
+
+class DataManagerPerf {
+    async updateBuildWithAggResult ( task ) {
+        if ( task.hasChildren ) {
+            const parentId = task._id;
+            let testResults = new TestResultsDB();
+            const childBuildList = await testResults.getData({parentId}).toArray();
+            if ( childBuildList && childBuildList.length > 0 ) {
+                const parentAggregationStructure = [];
+                let benchmarkName, benchmarkVariant, benchmarkProduct;
+                const childrenAggData = [];
+                const metricsCollection = {};
+                //loop into the child build list
+                for ( let j = 0; j < childBuildList.length; j++ ) {
+                    if (childBuildList[j].aggregateInfo && childBuildList[j].aggregateInfo.length > 0) {
+                        //loop into the each child's aggregate info.
+                        for (let k = 0 ; k < childBuildList[j].aggregateInfo.length; k++){
+                            benchmarkName = childBuildList[j].aggregateInfo[k].benchmarkName;
+                            benchmarkVariant = childBuildList[j].aggregateInfo[k].benchmarkVariant;
+                            benchmarkProduct = childBuildList[j].aggregateInfo[k].benchmarkProduct;
+                            if( childBuildList[j].aggregateInfo[k] && childBuildList[j].aggregateInfo[k].metrics && childBuildList[j].aggregateInfo[k].metrics.length > 0 ){
+                                //loop into each child's metrics
+                                for ( let {name, value} of childBuildList[j].aggregateInfo[k].metrics ){
+                                    const childMean = value.mean;
+                                    if ( !metricsCollection[name] ){
+                                        metricsCollection[name] = [childMean];
+                                    } else {
+                                        metricsCollection[name].push(childMean);
+                                    }
+                                    //remove the bad data, ie: null.
+                                    metricsCollection[name] = metricsCollection[name].filter (n => n);
+                                }
+                            }
+                        }
+                    }
+                }
+                Object.keys( metricsCollection ).forEach( function(key) {
+                    const meanMetric = math.mean(metricsCollection[key]);
+                    const maxMetric = math.max(metricsCollection[key]);
+                    const minMetric = math.min(metricsCollection[key]);
+                    const medianMetric = math.median(metricsCollection[key]);
+                    const stddevMetric = math.std(metricsCollection[key]);
+                    const ciMetric = BenchmarkMath.confidence_interval(metricsCollection[key]);
+                    childrenAggData.push({name: key, value: { mean: meanMetric, max: maxMetric, min: minMetric, median: medianMetric, stddev: stddevMetric, CI: ciMetric, iteration: metricsCollection[key].length } });
+                })
+                parentAggregationStructure.push({
+                    benchmarkName: benchmarkName,
+                    benchmarkVariant: benchmarkVariant,
+                    benchmarkProduct: benchmarkProduct,
+                    metrics: childrenAggData
+                });
+                const { _id, ...value } = task;
+                const criteria = { _id: new ObjectID( _id ) };
+                const update = {
+                    ...value
+                };
+                update.aggregateInfo = parentAggregationStructure;
+                const result = await testResults.update( criteria, { $set: update } );  
+            }
+        }         
+    }
+}
+module.exports = DataManagerPerf;

--- a/test-result-summary-client/package.json
+++ b/test-result-summary-client/package.json
@@ -10,7 +10,7 @@
     "highstock-release": "^6.0.4",
     "history": "^4.9.0",
     "jquery": "^3.3.1",
-    "mathjs": "^5.7.0",
+    "mathjs": "^5.9.0",
     "mergely": "^4.0.11",
     "moment": "^2.24.0",
     "npm-check": "^5.9.0",


### PR DESCRIPTION
This PR is referred to PR #85 (which was closed by mistake)

1. Aggregated information added to Perf type builds in the database, move the Benchmark Math calculation from the client side to backend to save the operation time.
2. Modification on the Perf Compare, especially on the raw data displaying.
#24 #70 #100 AdoptOpenJDK/openjdk-tests#850
Signed-off-by: sophiaxu0424 xmh1989@my.yorku.ca