### PR TITLE
Support Plugin structure

### DIFF
--- a/TestResultSummaryService/BuildProcessor.js
+++ b/TestResultSummaryService/BuildProcessor.js
@@ -6,6 +6,7 @@ const ParentBuild = require(`./parsers/ParentBuild`);
 const ObjectID = require('mongodb').ObjectID;
 const { TestResultsDB, OutputDB } = require('./Database');
 const { logger } = require('./Utils');
+const plugins = require('./plugins');
 
 class BuildProcessor {
     async execute(task) {
@@ -113,6 +114,8 @@ class BuildProcessor {
                         status: "Done"
                     });
                 }
+
+                await plugins.onBuildDone(task, { testResultsDB, logger });
             }
         }
     }

--- a/TestResultSummaryService/README.md
+++ b/TestResultSummaryService/README.md
@@ -4,7 +4,7 @@
 Project for logging test results and viewing history. Should be abstract enough for any build to log results to and present results in a personalized dashboard.
 
 ## Prerequisites
-* Node Version: 8.4.0 [Install Node](https://nodejs.org/en/download/)
+* Node Version: 11.4.0 [Install Node](https://nodejs.org/en/download/)
 * System Dependencies: npm (comes packaged with Node)
 * MongoDB 3.4 and above
 * Access to [Jenkins Instances](https://ci.adoptopenjdk.net)
@@ -89,3 +89,15 @@ Config file example:
 ```
 
 If any server name matches with url in `DashboardBuildInfo.json` or domain in build monitoring list, credentials will be used when querying these servers.
+
+##Build Status
+
+A build can have the following status in database:
+
+- `NotDone` - The inital state. The build is created in the database, but not all information is processed and stored.
+- `Streaming` - Special state. When enabled, the build will be processed while it is still running.
+- `CurrentBuildDone` - The current build is processed and all informaiton is stored in the database, but its child builds may not be done.
+- `Done` - The build and its child builds are processed and stored.
+
+## Plugins
+Plugins can be added. Please refer [Plugins ReadMe](./plugins/README.md) for implementation detail.

--- a/TestResultSummaryService/plugins/README.md
+++ b/TestResultSummaryService/plugins/README.md
@@ -1,0 +1,17 @@
+
+# Plugins
+
+Users can create their own plugins. The plugin files can be added under `plugins` folder or they can be stored in another repo. The program will try to find all available files under `plugins` folder at runtime.
+
+Below is the format of the plugin. For detail, please see `examplePlugin.js`
+
+```
+module.exports.onBuildDone = async (task, { testResultsDB, logger }) => {
+	...
+}
+
+```
+
+## Available functions
+
+`onBuildDone` -  it will be invoked when the status of the build is `Done`.

--- a/TestResultSummaryService/plugins/examplePlugin.js
+++ b/TestResultSummaryService/plugins/examplePlugin.js
@@ -1,0 +1,9 @@
+// This is an example plugin
+
+module.exports.onBuildDone = async (task, { testResultsDB, logger }) => {
+    logger.debug("onBuildDone", task.buildName);
+
+    // Example code for querying testResultsDB
+    // const result = await testResultsDB.getData({ parentId: task._id, status: { $ne: "Done" } }).toArray();
+    // logger.debug("onBuildDone", result.length);
+}

--- a/TestResultSummaryService/plugins/index.js
+++ b/TestResultSummaryService/plugins/index.js
@@ -1,0 +1,19 @@
+const fs = require('fs');
+
+// find all existing files (except index.js and README.md) under plugins folder and require them
+const plugins = fs.readdirSync("./plugins").filter(file => !file.startsWith("index") && !file.startsWith("README")).map(file => {
+    return require("./" + file);
+});
+
+// loop through all plugins to run the matching function
+const run = async (name, args) => {
+    for (let plugin of plugins) {
+        if (plugin[name]) {
+            await plugin[name].apply(plugin[name], args);
+        }
+    }
+}
+
+module.exports = {
+    onBuildDone: (...args) => run("onBuildDone", args),
+}


### PR DESCRIPTION
- With this structure, users can define their own plugins. The plugin
files can be added under `plugins` folder or they can be stored in
another repo. The program will try to find all available files under
`plugins` folder at runtime.
- Example plugin is added
- Updated readme

Closes: #99

Signed-off-by: lanxia <lan_xia@ca.ibm.com>