### PR TITLE
Extend dynamic fetching of HW environment variables

### DIFF
--- a/PerfNext/config/benchmarks/data_simple/Liberty.xml
+++ b/PerfNext/config/benchmarks/data_simple/Liberty.xml
@@ -14,22 +14,10 @@
 				<property name="MEASURE_TIME">180</property>
 				<property name="WARMUP_TIME">180</property>
 				<property name="RESULTS_MACHINE">lowry1</property>
-				<property name="RESULTS_DIR">libertyResults-cleaned</property>
-				<property name="CLIENT">perfxposh10G</property>
-				<property name="CLIENT_WORK_DIR">/java/perffarm/liberty</property>
-				<property name="DB_MACHINE">perfxposh10G</property>
-				<property name="DB2_HOME">/home/db2inst1/</property>
-				<property name="DB_NAME">day30r</property>
-				<property name="DB_PORT">50000</property>
-				<property name="DB_USR_NAME">db2inst1</property>
-				<property name="SERVER_NAME">DayTrader3-$JDK</property>
-				<property name="LIBERTY_HOST">kermit10G</property>
-				<property name="SECOND_CLIENT"></property>
-				<property name="THIRD_CLIENT"></property>
+				<property name="RESULTS_DIR">libertyResults-cleaned</property>			
+				<property name="SERVER_NAME">DayTrader3-$JDK</property>				
 				<property name="PROFILING_TOOL"></property>
 				<property name="PROFILING_JAVA_OPTION"></property>
-				<property name="LIBERTY_PORT">9080</property>
-				<property name="AFFINITY">numactl --physcpubind=0,1,36,37 --membind=0</property>
 				<property name="LARGE_THREAD_POOL">true</property>
 				<property name="JMETER_LOC">/java/perffarm/JMeter/apache-jmeter-2.12/bin/jmeter</property>
 				<property name="JMETER_INSTANCES"></property>
@@ -46,7 +34,7 @@
 				<property name="NO_SETUP">false</property>
 				<property name="LAUNCH_SCRIPT">server</property>
 				<property name="LIBERTY_BINARIES_DIR">$RUN_DIR/libertyBinaries</property>
-				<property name="LIBERTY_VERSION">liberty17003</property>        	
+				<property name="LIBERTY_VERSION">liberty19002</property>        	
             </ENV>
         </properties>
         <iterations>1</iterations>
@@ -72,13 +60,11 @@
 				<property name="SCENARIO">TradeLite</property>
 				<property name="SERVER_NAME">tradeLiteServer-$JDK</property>
 				<property name="PETERFP">false</property>
-				<property name="AFFINITY">numactl --physcpubind=0,1,36,37 --membind=0</property>
 				<property name="RESULTS_MACHINE">lowry1</property>
 				<property name="RESULTS_DIR">libertyResults</property>
-				<property name="LIBERTY_HOST">kermit10G</property>
 				<property name="LAUNCH_SCRIPT">server</property>
 				<property name="LIBERTY_BINARIES_DIR">$RUN_DIR/libertyBinaries</property>
-				<property name="LIBERTY_VERSION">liberty17003</property>            	
+				<property name="LIBERTY_VERSION">liberty19002</property>            	
             </ENV>
         </properties>
         <iterations>1</iterations>
@@ -104,13 +90,11 @@
 				<property name="SCENARIO">DayTrader</property>
 				<property name="SERVER_NAME">LibertySUDTServer-$JDK</property>
 				<property name="PETERFP">false</property>
-				<property name="AFFINITY">numactl --physcpubind=0,1,36,37 --membind=0</property>
 				<property name="RESULTS_MACHINE">lowry1</property>
 				<property name="RESULTS_DIR">libertyResults</property>
-				<property name="LIBERTY_HOST">kermit10G</property>
 				<property name="LAUNCH_SCRIPT">server</property>
 				<property name="LIBERTY_BINARIES_DIR">$RUN_DIR/libertyBinaries</property>
-				<property name="LIBERTY_VERSION">liberty17003</property> 
+				<property name="LIBERTY_VERSION">liberty19002</property> 
 				<property name="WLP_SKIP_MAXPERMSIZE">1</property>            	
             </ENV>
         </properties>
@@ -137,13 +121,11 @@
 				<property name="SCENARIO">HugeEJB</property>
 				<property name="SERVER_NAME">HugeEJBServer-$JDK</property>
 				<property name="PETERFP">false</property>
-				<property name="AFFINITY">numactl --physcpubind=0,1,36,37 --membind=0</property>
 				<property name="RESULTS_MACHINE">lowry1</property>
 				<property name="RESULTS_DIR">libertyResults</property>
-				<property name="LIBERTY_HOST">kermit10G</property>
 				<property name="LAUNCH_SCRIPT">server</property>
 				<property name="LIBERTY_BINARIES_DIR">$RUN_DIR/libertyBinaries</property>
-				<property name="LIBERTY_VERSION">liberty17003</property>            	
+				<property name="LIBERTY_VERSION">liberty19002</property>            	
             </ENV>
         </properties>
         <iterations>1</iterations>
@@ -163,21 +145,9 @@
 	          <property name="WARMUP_TIME">180</property>
 	          <property name="RESULTS_MACHINE">lowry1</property>
 	          <property name="RESULTS_DIR">libertyResults-cleaned</property>
-	          <property name="CLIENT">perfxposh10G</property>
-	          <property name="CLIENT_WORK_DIR">/java/perffarm/liberty</property>
-	          <property name="DB_MACHINE">perfxposh10G</property>
-	          <property name="DB2_HOME">/home/db2inst1/</property>
-	          <property name="DB_NAME">day30r</property>
-	          <property name="DB_PORT">50000</property>
-	          <property name="DB_USR_NAME">db2inst1</property>
 	          <property name="SERVER_NAME">AcmeAir-$JDK</property>
-	          <property name="LIBERTY_HOST">kermit10G</property>
-	          <property name="SECOND_CLIENT"></property>
-	          <property name="THIRD_CLIENT"></property>
 	          <property name="PROFILING_TOOL"></property>
 	          <property name="PROFILING_JAVA_OPTION"></property>
-	          <property name="LIBERTY_PORT">9080</property>
-	          <property name="AFFINITY">numactl --physcpubind=0,1,36,37 --membind=0</property>
 	          <property name="LARGE_THREAD_POOL">false</property>
 	          <property name="JMETER_LOC">/java/perffarm/JMeter/apache-jmeter-2.12/bin/jmeter</property>
 	          <property name="JMETER_INSTANCES"></property>
@@ -193,7 +163,7 @@
 	          <property name="NO_SETUP">false</property>
 	          <property name="LAUNCH_SCRIPT">server</property>
 	          <property name="LIBERTY_BINARIES_DIR">$RUN_DIR/libertyBinaries</property>
-	          <property name="LIBERTY_VERSION">liberty17003</property>
+	          <property name="LIBERTY_VERSION">liberty19002</property>
 	        </ENV>
 	   </properties>
 	   <iterations>1</iterations>
@@ -219,13 +189,11 @@
 				<property name="SCENARIO">AcmeAir</property>
 				<property name="SERVER_NAME">AcmeAir-sufp-$JDK</property>
 				<property name="PETERFP">false</property>
-				<property name="AFFINITY">numactl --physcpubind=0,1,36,37 --membind=0</property>
 				<property name="RESULTS_MACHINE">lowry1</property>
 				<property name="RESULTS_DIR">libertyResults</property>
-				<property name="LIBERTY_HOST">kermit10G</property>
 				<property name="LAUNCH_SCRIPT">server</property>
 				<property name="LIBERTY_BINARIES_DIR">$RUN_DIR/libertyBinaries</property>
-				<property name="LIBERTY_VERSION">liberty17003</property>            	
+				<property name="LIBERTY_VERSION">liberty19002</property>            	
             </ENV>
         </properties>
         <iterations>1</iterations>
@@ -245,21 +213,9 @@
                 <property name="WARMUP_TIME">180</property>
                 <property name="RESULTS_MACHINE">lowry1</property>
                 <property name="RESULTS_DIR">libertyResults</property>
-                <property name="CLIENT">lnxdbperf</property>
-                <property name="CLIENT_WORK_DIR">/java/perffarm/liberty</property>
-                <property name="DB_MACHINE">lnxdbperf</property>
-                <property name="DB2_HOME">/home/db2inst1/</property>
-                <property name="DB_NAME">day30r</property>
-                <property name="DB_PORT">50000</property>
-                <property name="DB_USR_NAME">db2inst1</property>
                 <property name="SERVER_NAME">AcmeAir-pxa6480sr5-20170519_01</property>
-                <property name="LIBERTY_HOST">lnxcliperf</property>
-                <property name="SECOND_CLIENT"></property>
-                <property name="THIRD_CLIENT"></property>
                 <property name="PROFILING_TOOL"></property>
                 <property name="PROFILING_JAVA_OPTION"></property>
-                <property name="LIBERTY_PORT">9080</property>
-                <property name="AFFINITY">numactl --physcpubind=0,1,12,13 --membind=0</property>
                 <property name="LARGE_THREAD_POOL">true</property>
                 <property name="JMETER_LOC">/java/perffarm/Jmeter/bin/jmeter</property>
                 <property name="JMETER_INSTANCES"></property>
@@ -295,21 +251,10 @@
 				<property name="WARMUP_TIME">180</property>
 				<property name="RESULTS_MACHINE">lowry1</property>
 				<property name="RESULTS_DIR">libertyResults-cleaned</property>
-				<property name="CLIENT">perfxposh10G</property>
-				<property name="CLIENT_WORK_DIR">/java/perffarm/liberty</property>
-				<property name="DB_MACHINE">perfxposh10G</property>
-				<property name="DB2_HOME">/home/db2inst1/</property>
-				<property name="DB_NAME">day30r</property>
-				<property name="DB_PORT">50000</property>
-				<property name="DB_USR_NAME">db2inst1</property>
 				<property name="SERVER_NAME">DayTrader7-$JDK</property>
-				<property name="LIBERTY_HOST">kermit10G</property>
-				<property name="SECOND_CLIENT"></property>
-				<property name="THIRD_CLIENT"></property>
 				<property name="PROFILING_TOOL"></property>
 				<property name="PROFILING_JAVA_OPTION"></property>
 				<property name="LIBERTY_PORT">9080</property>
-				<property name="AFFINITY">numactl --physcpubind=0,1,36,37 --membind=0</property>
 				<property name="LARGE_THREAD_POOL">true</property>
 				<property name="JMETER_LOC">/java/perffarm/JMeter/apache-jmeter-2.12/bin/jmeter</property>
 				<property name="JMETER_INSTANCES"></property>
@@ -325,7 +270,7 @@
 				<property name="NO_SETUP">false</property>
 				<property name="LAUNCH_SCRIPT">server</property>
 				<property name="LIBERTY_BINARIES_DIR">$RUN_DIR/libertyBinaries</property>
-				<property name="LIBERTY_VERSION">liberty17003</property>        	
+				<property name="LIBERTY_VERSION">liberty19002</property>        	
             </ENV>
         </properties>
         <iterations>1</iterations>
@@ -351,13 +296,11 @@
 				<property name="SCENARIO">DayTrader7</property>
 				<property name="SERVER_NAME">LibertySUDT7Server-$JDK</property>
 				<property name="PETERFP">false</property>
-				<property name="AFFINITY">numactl --physcpubind=0,1,36,37 --membind=0</property>
 				<property name="RESULTS_MACHINE">lowry1</property>
 				<property name="RESULTS_DIR">libertyResults</property>
-				<property name="LIBERTY_HOST">kermit10G</property>
 				<property name="LAUNCH_SCRIPT">server</property>
 				<property name="LIBERTY_BINARIES_DIR">$RUN_DIR/libertyBinaries</property>
-				<property name="LIBERTY_VERSION">liberty17003</property> 
+				<property name="LIBERTY_VERSION">liberty19002</property> 
 				<property name="WLP_SKIP_MAXPERMSIZE">1</property>            	
             </ENV>
         </properties>

--- a/PerfNext/config/benchmarks/data_simple/ODM.xml
+++ b/PerfNext/config/benchmarks/data_simple/ODM.xml
@@ -20,8 +20,6 @@
 				<property name="MAXHEAPSIZE">-Xmx1024m</property>
 				<property name="TENUREDSIZE"></property>
 				<property name="NURSERYSIZE"></property>
-				<property name="MULTITHREAD">4</property>
-				<property name="CPUAFFINITY">numactl --physcpubind=0,1,28,29 --membind=0</property>
             </ENV>
         </properties>
         <iterations>1</iterations>
@@ -46,8 +44,6 @@
 				<property name="MAXHEAPSIZE">-Xmx1024m</property>
 				<property name="TENUREDSIZE"></property>
 				<property name="NURSERYSIZE"></property>
-				<property name="MULTITHREAD">4</property>
-				<property name="CPUAFFINITY">numactl --physcpubind=0,1,28,29 --membind=0</property>
             </ENV>
         </properties>
         <iterations>1</iterations>

--- a/PerfNext/config/benchmarks/data_simple/SPEC.xml
+++ b/PerfNext/config/benchmarks/data_simple/SPEC.xml
@@ -11,14 +11,7 @@
                 <property name="JDK_OPTIONS">-Xaggressive -Dreflect.cache=boot -Dcom.ibm.enableClassCaching=true -Dcom.ibm.cacheLatestUserDefinedClassLoader=true -Dcom.ibm.crypto.provider.doAESInHardware=true -XtlhPrefetch -Xdump:java+system:events=user</property>
                 <property name="CTRL_OPTIONS"></property>
                 <property name="NO_GROUPS">2</property>
-                <property name="NO_INJECTORS">1</property>
-                <property name="HW_THREADS">56</property>
-                <property name="TI_OPTIONS">-Xms2g -Xmx2g -Xmn1500m -Xgcpolicy:gencon -Xlp -Xcompressedrefs</property>
-                <property name="BE_OPTIONS">-Xms24g -Xmx24g -Xmn20g -Xgcpolicy:gencon -Xlp -Xcompressedrefs</property>    
-                <property name="GRP1TXIAFF">numactl --cpunodebind=0 --membind=0</property>
-                <property name="GRP1BEAFF">numactl --cpunodebind=0 --membind=0</property>
-                <property name="GRP2TXIAFF">numactl --cpunodebind=1 --membind=1</property>
-                <property name="GRP2BEAFF">numactl --cpunodebind=1 --membind=1</property>        
+                <property name="NO_INJECTORS">1</property>        
             </ENV>
         </properties>
         <iterations>1</iterations>

--- a/PerfNext/public/pages/schedule.html
+++ b/PerfNext/public/pages/schedule.html
@@ -431,10 +431,10 @@
                                           <div class="form-group">
                                           	 <label>Machine CPU Affinity</label>
 											 <select id="machine-cpu-affinity" class="form-control drop-down-space">
-                                          	 	<option>2 cores</option>
-                                          	 	<option selected="selected">4 cores</option>
-                                          	 	<option>8 cores</option>
-                                          	 	<option>16 cores</option>
+                                          	 	<option>2-way</option>
+                                          	 	<option selected="selected">4-way</option>
+                                          	 	<option>8-way</option>
+                                          	 	<option>16-way</option>
                                           	 </select>  
                                              <div class="checkbox">
                                                 <label>


### PR DESCRIPTION
- Closes #32
- Removed hard coded hardware environment variables
- Extended functionality to look for capability in order to populate HW specific variables
- CPU Affinity calculations fixed, also name changed to 4-way instead of cores
- Soft coded NUM_THREADS variable to replace hard coded MULTITHREAD variable

Signed-off-by: Awsaf Arefin Sakif <awsaf.sakif@ibm.com>