### PR TITLE
Parser update

### DIFF
--- a/TestResultSummaryService/parsers/BenchmarkMetric.js
+++ b/TestResultSummaryService/parsers/BenchmarkMetric.js
@@ -1,60 +1,79 @@
-// Note: The correct value for the metric must always reside in indice 1 (second element) of the regex output array
+/* Note: The correct value for the metric must always reside in index 1 (capture group) of the regex output array
+*  use outerRegex when there are any warmup/cold runs before measure run that you do not wish to include.
+* if not familiar with regex look at other benchmarks & use https://regex101.com/ :)
+*
+* Please follow this convention for regex:
+* [\s\S\n] instead of [\s\S] or .
+* \d instead of [0-9]
+* \. instead of [.]
+* To capture a value (decimal or integer): \d*\.?\d* instead of \d+.\d+
+*
+* Format of each Benchmark
+* 	Benchmarkname: {
+* 	outerRegex:  Regex with capture group: all text(*) after warmup runs should be used
+*  NOTE : Outer regex is optional param should be only used when there are cold runs 
+*  that you do not wish to include as result
+*  metrics:
+*    [  // array of metrics
+*        { //individual metric
+*            name: name of the metric
+*            regex: Regex with capture group: value for the specific metric
+*        }, ...
+*    ]
+*/
 
 const BenchmarkMetricRegex = {
     LibertyDayTrader3: {
+    	outerRegex: /<run runNo="\d*" runType="measure"([\s\S\n]*)/,
         metrics: [
             {
-                name: "Throughput",
-                regex: /<run runNo="5" runType="measure">[\s\S]*?<metric type="throughput">\n?[\s\S]*?([0-9]*[.]?[0-9]+)<\/data>/,
-                regexRepeat: false
+                name: "Throughput", //Example: <metric type="throughput">\n<data machine="lance10G" units="req/sec">63.4</data>
+                regex: /<metric type="throughput">[\s\S\n]*?(\d*\.?\d*)<\/data>/,
+            },
+            {
+                name: "Footprint in kb", //Example: Footprint (kb)=589444
+                regex: /Footprint \(kb\)=(\d*\.?\d*)/,
             }
         ]
     },
     LibertyStartup: {
-        metrics: [
+        outerRegex: /Warm run \d*([\s\S\n]*)/,
+        metrics: [ 
             {
-                name: "Footprint in kb",
-                outerRegex: /\sWarm\srun\s0\s([\s\S]*)/,
-                regex: /\sFootprint\s\(kb\)=(.*)\s/g,
-                regexRepeat: true
+                name: "Footprint in kb", //Example: Footprint (kb)=168940
+                regex: /Footprint \(kb\)=(\d*\.?\d*)/,
             },
             {
-                name: "Startup time in ms",
-                outerRegex: /\sWarm\srun\s0\s([\s\S]*)/,
-                regex: /\sStartup\stime:\s(.*)\s/g,
-                regexRepeat: true
+                name: "Startup time in ms", //Example: Startup time: 7828
+                regex: /Startup time: (\d*\.?\d*)/,
             }
         ]
     },
     ILOG_WODM: {
         metrics: [
             {
-                name: "Global Throughput",
-                regex: /Global Throughput.*?=\s?([0-9]*[.]?[0-9]+)/,
-                regexRepeat: false
+                name: "Global Throughput", //Example: Global Throughput (TPS) for run = 7413.726308633243
+                regex: /Global Throughput[\s\S\n]*?= ?(\d*\.?\d*)/,
             }
         ]
     },
     SPECjbb2015: {
         metrics: [
             {
-                name: "max_jOPS",
-                regex: /RUN RESULT:[\s\S]*?max-jOPS\s?=\s?([0-9]*[.]?[0-9]+)[\s\S]*?critical-jOPS\s?=\s?[0-9]*[.]?[0-9]+[\s\S]*?\n/,
-                regexRepeat: false
+                name: "max_jOPS", //Example: RUN RESULT: hbIR (max attempted) = 47675, hbIR (settled) = 44200, max-jOPS = 41954, critical-jOPS = 15735
+                regex: /RUN RESULT:[\s\S\n]*?max-jOPS\s?=\s?(\d*\.?\d*)[\s\S\n]*?critical-jOPS\s?=\s?\d*\.?\d*[\s\S\n]*?\n/,
             },
             {
-                name: "critical_jOPS",
-                regex: /RUN RESULT:[\s\S]*?max-jOPS\s?=\s?[0-9]*[.]?[0-9]+[\s\S]*?critical-jOPS\s?=\s?([0-9]*[.]?[0-9]+)[\s\S]*?\n/,
-                regexRepeat: false
+                name: "critical_jOPS", //same line as above different capture point
+                regex: /RUN RESULT:[\s\S\n]*?max-jOPS\s?=\s?\d*\.?\d*[\s\S\n]*?critical-jOPS\s?=\s?(\d*\.?\d*)[\s\S\n]*?\n/,
             }
         ]
     },
     AcmeAirNodejs: {
         metrics: [
             {
-                name: "Throughput",
-                regex: /Throughput: (\d*\.?\d*)/, //Example: "Throughput: 3554.1"
-                regexRepeat: false
+                name: "Throughput", //Example: Throughput: 3554.1
+                regex: /Throughput: (\d*\.?\d*)/ 
             }
         ]
     }

--- a/TestResultSummaryService/parsers/BenchmarkMetricRouter.js
+++ b/TestResultSummaryService/parsers/BenchmarkMetricRouter.js
@@ -8,7 +8,11 @@ const BenchmarkMetricRouter = {
         "17dev-4way-LargeThreadPoolwarm": "LibertyDayTrader3"
     },
     "LibertyStartup": {
-        "9dev-4way-0-256-qs": "LibertyStartup"
+        "9dev-4way-0-256-qs": "LibertyStartup",
+        "17dev-4way-0-256-qs": "LibertyStartup"
+    },
+    "LibertyStartupAcmeAir": {
+        "17dev-4way-0-256-qs": "LibertyStartup"
     },
     "LibertyStartupDT": {
         "17dev-4way-0-256-qs": "LibertyStartup"


### PR DESCRIPTION
Closes #124 
1. Removed Regex repeat  & removed regex repeat check
2. OuterRegex is factored out from [Benchmark].[metrics].[outerregex] to [Benchmark].[outerregex]
3. change to liberty hard-coded number regex so it won't be affected by # of warmup runs
4. Removed checks that checks fields in the BenchmarkMetric.js file
5. Added comments BenchmarkMetric.js to give general structure of what a benchmark metric should look like 