### PR TITLE
Adding Tabular View for comparing baseline and test builds for selected platforms and metrics

### DIFF
--- a/TestResultSummaryService/package-lock.json
+++ b/TestResultSummaryService/package-lock.json
@@ -2773,7 +2773,7 @@
         },
         "got": {
           "version": "6.7.1",
-          "resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
+          "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
           "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
           "dev": true,
           "requires": {

--- a/TestResultSummaryService/parsers/BenchmarkParser.js
+++ b/TestResultSummaryService/parsers/BenchmarkParser.js
@@ -6,6 +6,7 @@ const benchmarkDelimiterRegex = /[\r\n]\*\*\*\*\*\*\*\*\*\* START OF NEW TESTCI 
 const benchmarkNameRegex = /[\r\n]Benchmark Name: (.*) Benchmark Variant: .*[\r\n]/;
 const benchmarkVariantRegex = /[\r\n]Benchmark Name: .* Benchmark Variant: (.*)[\r\n]/;
 const benchmarkProductRegex = /[\r\n]Benchmark Product: (.*)[\r\n]/;
+const productResourceRegex = /[\r\n]Product Resource: (.*)[\r\n]/;
 const javaVersionRegex = /(java version[\s\S]*JCL.*\n)/;
 const javaBuildDateRegex = /-(20[0-9][0-9][0-9][0-9][0-9][0-9])_/;
 
@@ -56,6 +57,7 @@ class BenchmarkParser extends Parser {
             let curMetricValue = null;
             let curJavaBuildDate = null;
             let curJavaVersion = null;
+            let curProductResource = null;
             let isValid = true;
             let curTestData = {};
 
@@ -87,6 +89,10 @@ class BenchmarkParser extends Parser {
             // Parse benchmark product
             if ( ( curRegexResult = benchmarkProductRegex.exec( curItr.value ) ) !== null ) {
                 curBenchmarkProduct = curRegexResult[1];
+            }
+            
+            if ( ( curRegexResult = productResourceRegex.exec( curItr.value ) ) !== null ) {
+                curProductResource = curRegexResult[1];
             }
 
             if ( isValid ) {
@@ -150,7 +156,8 @@ class BenchmarkParser extends Parser {
                 benchmarkName: curBenchmarkName,
                 benchmarkVariant: curBenchmarkVariant,
                 benchmarkProduct: curBenchmarkProduct,
-                testData: curTestData
+                testData: curTestData,
+                sdkResource: curProductResource,
             } );
 
             curItr = benchmarkIterator.next();

--- a/TestResultSummaryService/routes/getTabularData.js
+++ b/TestResultSummaryService/routes/getTabularData.js
@@ -1,0 +1,72 @@
+const { TestResultsDB, ObjectID } = require( '../Database' );
+
+function exceedDate(jdkDate) {
+    return function(element) {
+       return parseInt(element.aggregateInfo[0].benchmarkProduct.slice(-8)) <= parseInt(jdkDate);
+    }
+}
+
+
+module.exports = async ( req, res ) => {
+    const data = [];
+    const db = new TestResultsDB();
+    
+    const datas = [];
+    // TODO: Use available api to get build directly
+    const query = {buildName: {$regex: ".*_" + req.query.jdkVersion + "_" + req.query.jvmType + ".*perf_.*"}, url: req.query.buildServer};
+    
+    // Get list of distinct platforms and benchmarks that match the JDK pipeline
+    const platBenchList = await db.aggregate( [
+        {
+            $match: query
+        },
+        // Needed to access values inside array
+        {$unwind: "$aggregateInfo"},
+        {$group :
+            {
+                _id:0,
+                buildNames: {$addToSet: '$buildName'},
+                benchmarks: {$addToSet: '$aggregateInfo.benchmarkName'},
+    }}
+    ] );
+    
+    let {platforms, benchmarks} = [];
+    // Error handling in case no builds are found
+    if (platBenchList[0]) {
+        platforms = platBenchList[0].buildNames;
+        benchmarks = platBenchList[0].benchmarks;
+    }
+    // Extra check to return builds whose sdkResource field does not exist or is null.
+    let sdkResourceQuery;
+    if (req.query.sdkResource === "null") {
+    	sdkResourceQuery = null;
+    } else {
+    	sdkResourceQuery = req.query.sdkResource;
+    }
+    
+    for (benchmarkIndex in benchmarks) {
+        let benchmarkQuery;
+        // Return all entries that match the current benchmark and platform
+        for (item in platforms) {
+            benchmarkQuery = {$and: [{ buildName: { $regex : platforms[item] }, sdkResource: sdkResourceQuery}, { aggregateInfo: { $elemMatch: { benchmarkName: benchmarks[benchmarkIndex] }}}
+            ] };
+            const result = await db.getData(benchmarkQuery).toArray();
+
+            // Remove all entries whose build date exceeds the chosen date
+            const exceedFilter = result.filter(exceedDate(req.query.jdkDate));
+            // Setting the latest build date from the available dates
+            const latestDate = Math.max.apply(Math, exceedFilter.map(function(o) { return parseInt(o.aggregateInfo[0].benchmarkProduct.slice(-8)); }));
+            // Remove all runs that are not the latest
+            const dateFilter = exceedFilter.filter(entry => parseInt(entry.aggregateInfo[0].benchmarkProduct.slice(-8)) === latestDate);
+            const latest = Math.max.apply(Math, dateFilter.map(function(o) { return o.timestamp; }));
+            // Keep the latest build with the latest timestamp
+            const latestRun = dateFilter.find(function(o){ return o.timestamp == latest; })
+
+            if (latestRun !== undefined) {datas.push( latestRun );}
+        }
+    }
+    // Return the list of unique pipeline names for column generation
+    const buildNames = [...new Set(datas.map(item => item.buildName))];
+    datas.push(buildNames);
+    res.send(datas);
+}

--- a/TestResultSummaryService/routes/getTabularDropdown.js
+++ b/TestResultSummaryService/routes/getTabularDropdown.js
@@ -1,0 +1,40 @@
+const { TestResultsDB, ObjectID } = require( '../Database' );
+const ArgParser = require('../ArgParser');
+
+module.exports = async ( req, res ) => {
+    const db = new TestResultsDB();
+    const query = {buildName: {$regex: ".*perf_.*"}};
+    
+    const server = ArgParser.getConfig() === undefined ? {} : ArgParser.getConfig().defaultTabularViewJenkins;
+    // Get all unique buildNames, sdkResource, url from database
+    const data = await db.aggregate( [
+        {
+            $match: query
+        },
+        {$group :
+       {
+          _id:0,
+          buildNames: {$addToSet: '$buildName'},
+          sdkResource: {$addToSet: '$sdkResource'},
+          buildServer: {$addToSet: '$url'},
+    }}
+    ] );
+    //Based on buildName convention, assume index 1 is openjdk version, index 2 is jvm type
+    let jdkVersion = new Set();
+    let jvmType = new Set();
+    for (buildName in data[0].buildNames) {
+        let buildNameSplit = data[0].buildNames[buildName].split('_');
+        jdkVersion.add(buildNameSplit[1]);
+        jvmType.add(buildNameSplit[2]);
+    }
+    // Data is an array with a single item
+    data[0].jdkVersion = Array.from(jdkVersion);
+    data[0].jvmType = Array.from(jvmType);
+
+    // Make sure null is at the top of the dropdown
+    data[0].sdkResource = data[0].sdkResource.filter(n => n);
+    data[0].sdkResource.unshift(null);
+
+    res.send( data[0] );
+
+}

--- a/TestResultSummaryService/routes/index.js
+++ b/TestResultSummaryService/routes/index.js
@@ -20,6 +20,8 @@ app.get( '/getOutputByTestInfo', wrap( require( "./getOutputByTestInfo" ) ) );
 app.get( '/getTestInfoByBuildInfo', wrap( require( "./getTestInfoByBuildInfo" ) ) );
 app.get( '/getParents', wrap( require( "./getParents" ) ) );
 app.get( '/getPerffarmRunCSV', wrap( require( "./getPerffarmRunCSV" ) ) );
+app.get( '/getTabularData', wrap( require( "./getTabularData" ) ) );
+app.get( '/getTabularDropdown', wrap( require( "./getTabularDropdown" ) ) );
 app.get( '/getTestById', wrap( require( "./getTestById" ) ) );
 app.get( '/getTestBySearch', wrap( require( "./getTestBySearch" ) ) );
 app.get( '/getTestPerPlatform', wrap( require( "./getTestPerPlatform" ) ) );

--- a/test-result-summary-client/package-lock.json
+++ b/test-result-summary-client/package-lock.json
@@ -1075,9 +1075,9 @@
       },
       "dependencies": {
         "@hapi/hoek": {
-          "version": "8.2.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.2.0.tgz",
-          "integrity": "sha512-pR2ZgiP562aiaQvQ98WgfqfTrm+xG+7hwHRPEiYZ+7U1OHAAb4OVZJIalCP03bMqYSioQzflzVTVrybSwDBn1Q==",
+          "version": "8.2.1",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.2.1.tgz",
+          "integrity": "sha512-JPiBy+oSmsq3St7XlipfN5pNA6bDJ1kpa73PrK/zR29CVClDVqy04AanM/M/qx5bSF+I61DdCfAvRrujau+zRg==",
           "dev": true
         }
       }
@@ -1141,9 +1141,9 @@
           "dev": true
         },
         "graceful-fs": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.1.tgz",
-          "integrity": "sha512-b9usnbDGnD928gJB3LrCmxoibr3VE4U2SMo5PBuBnokWyDADTqDPXg4YpwKF1trpH+UbGp7QLicO3+aWEy0+mw==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+          "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
           "dev": true
         },
         "strip-ansi": {
@@ -1235,9 +1235,9 @@
           "dev": true
         },
         "graceful-fs": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.1.tgz",
-          "integrity": "sha512-b9usnbDGnD928gJB3LrCmxoibr3VE4U2SMo5PBuBnokWyDADTqDPXg4YpwKF1trpH+UbGp7QLicO3+aWEy0+mw==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+          "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
           "dev": true
         },
         "source-map": {
@@ -1295,9 +1295,9 @@
       },
       "dependencies": {
         "graceful-fs": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.1.tgz",
-          "integrity": "sha512-b9usnbDGnD928gJB3LrCmxoibr3VE4U2SMo5PBuBnokWyDADTqDPXg4YpwKF1trpH+UbGp7QLicO3+aWEy0+mw==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+          "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
           "dev": true
         },
         "source-map": {
@@ -3123,9 +3123,9 @@
       },
       "dependencies": {
         "graceful-fs": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.1.tgz",
-          "integrity": "sha512-b9usnbDGnD928gJB3LrCmxoibr3VE4U2SMo5PBuBnokWyDADTqDPXg4YpwKF1trpH+UbGp7QLicO3+aWEy0+mw==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+          "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
           "dev": true
         },
         "lru-cache": {
@@ -3393,12 +3393,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -3413,17 +3415,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -3540,7 +3545,8 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -3552,6 +3558,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -3566,6 +3573,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -3573,12 +3581,14 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -3597,6 +3607,7 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -3677,7 +3688,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -3689,6 +3701,7 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -3810,6 +3823,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -5498,9 +5512,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.224",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.224.tgz",
-      "integrity": "sha512-vTH9UcMbi53x/pZKQrEcD83obE8agqQwUIx/G03/mpE1vzLm0KA3cHwuZXCysvxI1gXfNjV7Nu7Vjtp89kDzmg==",
+      "version": "1.3.225",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.225.tgz",
+      "integrity": "sha512-7W/L3jw7HYE+tUPbcVOGBmnSrlUmyZ/Uyg24QS7Vx0a9KodtNrN0r0Q/LyGHrcYMtw2rv7E49F/vTXwlV/fuaA==",
       "dev": true
     },
     "elliptic": {
@@ -5674,9 +5688,9 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.1.tgz",
-      "integrity": "sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.12.0.tgz",
+      "integrity": "sha512-TuA+EhsanGcme5T3R0L80u4t8CpbXQjegRmf7+FPTJrtCTErXFeelblRgHQa1FofEzqYYJmJ/OqjTwREp9qgmg==",
       "dev": true,
       "requires": {
         "esprima": "^3.1.3",
@@ -5823,9 +5837,9 @@
       }
     },
     "eslint-config-react-app": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-5.0.0.tgz",
-      "integrity": "sha512-d3hbvu14J1Iy7N+XvrMOMXmw32iIGGIHqg7DK0RqA6UxKOix+Z53fuQ/uf2NqasSse3uHUNB1EvuZ8Iw2bzd3g==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-5.0.1.tgz",
+      "integrity": "sha512-GYXP3F/0PSHlYfGHhahqnJze8rYKxzXgrzXVqRRd4rDO40ga4NA3aHM7/HKbwceDN0/C1Ij3BoAWFawJgRbXEw==",
       "dev": true,
       "requires": {
         "confusing-browser-globals": "^1.0.8"
@@ -6138,9 +6152,9 @@
       }
     },
     "eslint-visitor-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+      "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
       "dev": true
     },
     "espree": {
@@ -6178,9 +6192,9 @@
       }
     },
     "estraverse": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true
     },
     "esutils": {
@@ -7265,9 +7279,9 @@
       "dev": true
     },
     "highcharts": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-7.1.2.tgz",
-      "integrity": "sha512-diSTVxWKefQzShi22gaV63pdrIFlQAsTGe3f328Ur7cqBoYFvHMtiMP+q+VOFdM2mdGVtlUR0QQSxj62LLsPpg=="
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-7.1.3.tgz",
+      "integrity": "sha512-aHAzlSf/czqJlpVt96jYkirWrIV1ZNHgxsTAyk2R5CcG/0V1G8Ge65p76eFqZQp7C8+cA8e6g1xsAPj51MsJ3Q=="
     },
     "highlight-es": {
       "version": "1.0.3",
@@ -9066,9 +9080,9 @@
           }
         },
         "graceful-fs": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.1.tgz",
-          "integrity": "sha512-b9usnbDGnD928gJB3LrCmxoibr3VE4U2SMo5PBuBnokWyDADTqDPXg4YpwKF1trpH+UbGp7QLicO3+aWEy0+mw==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+          "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
           "dev": true
         }
       }
@@ -9218,9 +9232,9 @@
           }
         },
         "graceful-fs": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.1.tgz",
-          "integrity": "sha512-b9usnbDGnD928gJB3LrCmxoibr3VE4U2SMo5PBuBnokWyDADTqDPXg4YpwKF1trpH+UbGp7QLicO3+aWEy0+mw==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+          "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
           "dev": true
         }
       }
@@ -9257,9 +9271,9 @@
       },
       "dependencies": {
         "graceful-fs": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.1.tgz",
-          "integrity": "sha512-b9usnbDGnD928gJB3LrCmxoibr3VE4U2SMo5PBuBnokWyDADTqDPXg4YpwKF1trpH+UbGp7QLicO3+aWEy0+mw==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+          "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
           "dev": true
         },
         "strip-bom": {
@@ -9329,9 +9343,9 @@
           "dev": true
         },
         "graceful-fs": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.1.tgz",
-          "integrity": "sha512-b9usnbDGnD928gJB3LrCmxoibr3VE4U2SMo5PBuBnokWyDADTqDPXg4YpwKF1trpH+UbGp7QLicO3+aWEy0+mw==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+          "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
           "dev": true
         },
         "is-ci": {
@@ -12881,9 +12895,9 @@
       }
     },
     "rc-collapse": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/rc-collapse/-/rc-collapse-1.11.3.tgz",
-      "integrity": "sha512-yECQX2iDPWnKcVi3Wz5bomZuJ2u+wv+kGxuKo2GIRz7Brh9jkGQz5ElghCV1jqDGnzy8GIRxxHHSwlSgdxdUog==",
+      "version": "1.11.5",
+      "resolved": "https://registry.npmjs.org/rc-collapse/-/rc-collapse-1.11.5.tgz",
+      "integrity": "sha512-PY6ZOPXZcpz7tFYpLp4rkD4hlCwLt2nSiMQB2ZLbEzW62yUN10/LxC/pPKWqeCQ9ejjmhNcCYTEdsdDwlZplXQ==",
       "requires": {
         "classnames": "2.x",
         "css-animation": "1.x",
@@ -13047,9 +13061,9 @@
       }
     },
     "rc-progress": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/rc-progress/-/rc-progress-2.5.1.tgz",
-      "integrity": "sha512-jIoCYAktSG1SvA7gu2jM7hYwb2JiBrqOexY80TBiIIznhMDHh1Mb7rvtfIoEF3WS5evoqoKa3A+szGMyv3J9Cw==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/rc-progress/-/rc-progress-2.5.2.tgz",
+      "integrity": "sha512-ajI+MJkbBz9zYDuE9GQsY5gsyqPF7HFioZEDZ9Fmc+ebNZoiSeSJsTJImPFCg0dW/5WiRGUy2F69SX1aPtSJgA==",
       "requires": {
         "babel-runtime": "6.x",
         "prop-types": "^15.5.8"
@@ -13415,9 +13429,9 @@
       }
     },
     "react-dev-utils": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-9.0.2.tgz",
-      "integrity": "sha512-AHVfRepMzZJyJHCNFAsrAG4El1H5v+27c1XkeDoX6pSmdhT/ZDdAN3Mf7DKYcrbIFlubzVYof6NZDnPBjd0CNA==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-9.0.3.tgz",
+      "integrity": "sha512-OyInhcwsvycQ3Zr2pQN+HV4gtRXrky5mJXIy4HnqrWa+mI624xfYfqGuC9dYbxp4Qq3YZzP8GSGQjv0AgNU15w==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.5.5",
@@ -13439,7 +13453,7 @@
         "loader-utils": "1.2.3",
         "open": "^6.3.0",
         "pkg-up": "2.0.0",
-        "react-error-overlay": "^6.0.0",
+        "react-error-overlay": "^6.0.1",
         "recursive-readdir": "2.2.2",
         "shell-quote": "1.6.1",
         "sockjs-client": "1.3.0",
@@ -13648,9 +13662,9 @@
       }
     },
     "react-error-overlay": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.0.tgz",
-      "integrity": "sha512-oHf3b1J2Pxu03apiHvP21qBCkj6fG6A3c3ahya3fX0VXEZUTzIRLwZI9eZ/6cuOO+kvnzdVdGBxZlo+Tjh+hfQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.1.tgz",
+      "integrity": "sha512-V9yoTr6MeZXPPd4nV/05eCBvGH9cGzc52FN8fs0O0TVQ3HYYf1n7EgZVtHbldRq5xU9zEzoXIITjYNIfxDDdUw==",
       "dev": true
     },
     "react-grid-layout": {
@@ -13789,9 +13803,9 @@
       }
     },
     "react-scripts": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-3.1.0.tgz",
-      "integrity": "sha512-JuccnZ+mKYhufZSxNoikMMX7KKvpq4dhiyR4jzsKDMJIu0fcdcXvjnBWKNMzRKmeXnmbeCjo1K9N/I57ZYpp4w==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-3.1.1.tgz",
+      "integrity": "sha512-dbjTG9vJC61OI62hIswQYg5xHvwlxDTH6QXz6ICEuA5AqkFQWk1LKl76sk8fVL2WsyumbBc4FErALwKcEV2vNA==",
       "dev": true,
       "requires": {
         "@babel/core": "7.5.5",
@@ -13809,7 +13823,7 @@
         "dotenv": "6.2.0",
         "dotenv-expand": "4.2.0",
         "eslint": "^6.1.0",
-        "eslint-config-react-app": "^5.0.0",
+        "eslint-config-react-app": "^5.0.1",
         "eslint-loader": "2.2.1",
         "eslint-plugin-flowtype": "3.13.0",
         "eslint-plugin-import": "2.18.2",
@@ -13835,7 +13849,7 @@
         "postcss-preset-env": "6.7.0",
         "postcss-safe-parser": "4.0.1",
         "react-app-polyfill": "^1.0.2",
-        "react-dev-utils": "^9.0.2",
+        "react-dev-utils": "^9.0.3",
         "resolve": "1.12.0",
         "resolve-url-loader": "3.1.0",
         "sass-loader": "7.2.0",
@@ -13868,6 +13882,14 @@
         "json2mq": "^0.2.0",
         "lodash.debounce": "^4.0.8",
         "resize-observer-polyfill": "^1.5.0"
+      }
+    },
+    "react-table": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/react-table/-/react-table-6.10.0.tgz",
+      "integrity": "sha512-s/mQLI1+mNvlae45MfAZyZ04YIT3jUzWJqx34s0tfwpDdgJkpeK6vyzwMUkKFCpGODBxpjBOekYZzcEmk+2FiQ==",
+      "requires": {
+        "classnames": "^2.2.5"
       }
     },
     "read-pkg": {

--- a/test-result-summary-client/package.json
+++ b/test-result-summary-client/package.json
@@ -6,7 +6,7 @@
     "antd": "^3.21.4",
     "classnames": "^2.2.6",
     "codemirror": "^5.48.2",
-    "highcharts": "^7.1.2",
+    "highcharts": "^7.1.3",
     "highstock-release": "^6.0.4",
     "history": "^4.9.0",
     "jquery": "^3.4.1",
@@ -24,7 +24,8 @@
     "react-jsx-highcharts": "^3.6.1",
     "react-jsx-highstock": "^3.6.1",
     "react-router": "^5.0.1",
-    "react-router-dom": "^5.0.1"
+    "react-router-dom": "^5.0.1",
+    "react-table": "^6.10.0"
   },
   "scripts": {
     "start": "react-app-rewired start",
@@ -34,7 +35,7 @@
   "proxy": "http://localhost:3001",
   "devDependencies": {
     "react-app-rewired": "^2.1.3",
-    "react-scripts": "^3.1.0"
+    "react-scripts": "^3.1.1"
   },
   "browserslist": [
     ">0.2%",

--- a/test-result-summary-client/src/App.jsx
+++ b/test-result-summary-client/src/App.jsx
@@ -9,6 +9,7 @@ import ErrorBoundary from './ErrorBoundary';
 import { Output } from './Build/Output/';
 import { TestCompare } from './TestCompare/';
 import { PerfCompare } from './PerfCompare/';
+import { TabularView } from './TabularView/';
 import { AllTestsInfo, BuildDetail, DeepHistory, TestPerPlatform, TopLevelBuilds, ResultGrid } from './Build/';
 import { SearchResult } from './Search/';
 import { Settings } from './Settings/';
@@ -49,6 +50,7 @@ export default class App extends Component {
                                 <Menu.Item key="3"><Link to="/tests/Perf">Perf Test</Link></Menu.Item>
                                 <Menu.Item key="4"><Link to="/testCompare">Test Compare</Link></Menu.Item>
                                 <Menu.Item key="5"><Link to="/perfCompare">Perf Compare</Link></Menu.Item>
+                                <Menu.Item key="6"><Link to="/tabularView">Tabular View</Link></Menu.Item>
                             </SubMenu>
                         </Menu>
                     </Sider>
@@ -63,6 +65,7 @@ export default class App extends Component {
                                 <Route path="/deepHistory" component={DeepHistory} />
                                 <Route path="/testCompare" component={TestCompare} />
                                 <Route path="/perfCompare" component={PerfCompare} />
+                                <Route path="/tabularView" component={TabularView} />
                                 <Route path="/buildDetail" component={BuildDetail} />
                                 <Route path="/allTestsInfo" component={AllTestsInfo} />
                                 <Route path="/testPerPlatform" component={TestPerPlatform} />

--- a/test-result-summary-client/src/PerfCompare/PerfCompare.jsx
+++ b/test-result-summary-client/src/PerfCompare/PerfCompare.jsx
@@ -5,6 +5,7 @@ import { stringify } from 'qs';
 import PerffarmRunJSON from './lib/PerffarmRunJSON';
 import JenkinsRunJSON from './lib/JenkinsRunJSON';
 import benchmarkVariantsInfo from './lib/benchmarkVariantsInfo';
+import { getParams } from '../utils/query';
 import './PerfCompare.css';
 
 const perfCompareColumns = [{
@@ -59,8 +60,14 @@ export default class PerfCompare extends Component {
         }
     };
 
-    componentDidMount() {
-
+    async componentDidMount() {
+    	let inputURL = {}
+        const urlData = getParams(window.location.search);
+        for (let url in urlData) {
+        	inputURL[url] = urlData[url];
+        }
+        await this.setState({inputURL: inputURL});
+        this.handleParseInputURL();
     }
 
     handleChange(event) {

--- a/test-result-summary-client/src/TabularView/TabularView.css
+++ b/test-result-summary-client/src/TabularView/TabularView.css
@@ -1,0 +1,76 @@
+.ReactTable .rt-td {
+  text-align: center;
+  color: black;
+  white-space: normal;
+  border: 2px solid rgba(0, 0, 0, 0.5);
+}
+
+.column {
+  float: left;
+  width: 33.33%;
+  font: 30px,
+}
+
+/* Clear floats after the columns */
+.row:after {
+  content: "";
+  display: table;
+  clear: both;
+  font-family: arial black;
+  
+}
+
+.select-css {
+	display: block;
+	font-size: 16px;
+	font-family: sans-serif;
+	font-weight: 700;
+	color: #444;
+	line-height: 0.9;
+	padding: .6em 1.4em .5em .8em;
+	width: 80%;
+	max-width: 100%;
+	box-sizing: border-box;
+	margin: 0;
+	border: 1px solid #aaa;
+	box-shadow: 0 1px 0 1px rgba(0,0,0,.04);
+	border-radius: .5em;
+	-moz-appearance: none;
+	-webkit-appearance: none;
+	appearance: none;
+	background-color: #fff;
+	background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%23007CB2%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.5-3.5%205.4-7.8%205.4-12.8%200-5-1.9-9.2-5.5-12.8z%22%2F%3E%3C%2Fsvg%3E'),
+	  linear-gradient(to bottom, #ffffff 0%,#e5e5e5 100%);
+	background-repeat: no-repeat, repeat;
+	background-position: right .7em top 50%, 0 0;
+	background-size: .65em auto, 100%;
+}
+.select-css::-ms-expand {
+	display: none;
+}
+.select-css:hover {
+	border-color: #888;
+}
+.select-css:focus {
+	border-color: #aaa;
+	box-shadow: 0 0 1px 3px rgba(59, 153, 252, .7);
+	box-shadow: 0 0 0 3px -moz-mac-focusring;
+	color: #222;
+	outline: none;
+}
+.select-css option {
+	font-weight:normal;
+}
+
+*[dir="rtl"] .select-css, :root:lang(ar) .select-css, :root:lang(iw) .select-css {
+	background-position: left .7em top 50%, 0 0;
+	padding: .6em .8em .5em 1.4em;
+}
+.select-css:disabled, .select-css[aria-disabled=true] {
+	color: graytext;
+	background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22graytext%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.5-3.5%205.4-7.8%205.4-12.8%200-5-1.9-9.2-5.5-12.8z%22%2F%3E%3C%2Fsvg%3E'),
+	  linear-gradient(to bottom, #ffffff 0%,#e5e5e5 100%);
+}
+.select-css:disabled:hover, .select-css[aria-disabled=true] {
+	border-color: #aaa;
+}

--- a/test-result-summary-client/src/TabularView/TabularView.jsx
+++ b/test-result-summary-client/src/TabularView/TabularView.jsx
@@ -1,0 +1,751 @@
+import React, { Component } from 'react';
+import { Button, Tooltip, Icon, Collapse, Checkbox, TreeSelect } from 'antd';
+import ReactTable from 'react-table'
+import './TabularView.css';
+import 'react-table/react-table.css'
+import PropTypes from 'prop-types';
+import DayPickerInput from 'react-day-picker/DayPickerInput';
+import { getParams } from '../utils/query';
+import 'react-day-picker/lib/style.css';
+import benchmarkVariantsInfo from '../PerfCompare/lib/benchmarkVariantsInfo';
+import tabularViewConfig from './TabularViewConfig';
+
+// Pull property panel from Collapse, so you do not have to write Collapse.Panel each time
+const { Panel } = Collapse;
+// Pull property SHOW_PARENT from TreeSelect, so you do not have to write TreeSelect.SHOW_PARENT each time
+const { SHOW_PARENT } = TreeSelect;
+
+// Setting color filter ranges, higher value is inclusive, lower value is exclusive
+const greenFilter = [98, Number.MAX_SAFE_INTEGER];
+const yellowFilter = [90, 98];
+const redFilter = [0, 90];
+
+const colStyle={fontSize:18, fontFamily: 'arial'};
+
+const legendColumns = [{
+    Header: 'Color',
+    accessor: 'colorName'
+    },
+    {Header: 'Score Range',
+    accessor: 'score'
+    },
+    {Header: 'Performance Analysis',
+    accessor: 'analysis'
+    },
+];
+	
+const legendRows = [{
+    colorName: 'Green',
+    color: '#2dc937',
+    score: ">98%",
+    analysis: "No Regression"
+    }, {
+    colorName: 'Yellow',
+    color: '#F0F755',
+    score: "91-98%",
+    analysis: "Possible Regression"
+    }, {
+    colorName: 'Red',
+    color: '#cc3232',
+    score: "<90%",
+    analysis: "Regression"
+    },
+   {colorName: 'Grey',
+    color: 'grey',
+    score: "N/A",
+    analysis: "No Data"
+   	},
+   {colorName: 'Off-White',
+    color: '#ffdbac',
+    score: "0 %",
+    analysis: "Only test/baseline data available"
+   	}];
+
+// Overlay for the date picker component
+function CustomOverlay({ classNames, selectedDay, children, ...props }) {
+    return (
+        <div
+        className={classNames.overlayWrapper}
+        style={{ marginLeft: -100 }}
+        {...props}
+    >
+        <div className={classNames.overlay}>
+        <p>
+            {selectedDay
+            ? `Currently Chosen JDK Date: ${selectedDay.toLocaleDateString()}`
+            : 'Choose JDK Date'}
+        </p>
+        {children}
+        </div>
+    </div>
+);}
+
+CustomOverlay.propTypes = {
+    classNames: PropTypes.object.isRequired,
+    selectedDay: PropTypes.instanceOf(Date),
+    children: PropTypes.node.isRequired,
+};
+
+export default class TabularView extends Component {
+    constructor(props) {
+    super(props);
+    this.handleDayChange = this.handleDayChange.bind(this);
+    this.state = {testData: [], columns : [], originalColumns: [], platforms: [], baselineData: [], consolidatedData: [], platformFilter: [], colorFilter: "all", benchmarkFilter: [], tabularDropdown: [],
+    defaultValues: tabularViewConfig};
+    }
+ 
+    async componentDidMount() {
+        const URLdata = getParams(window.location.search);
+        for (let key in URLdata) {
+            this.setState({[key]: URLdata[key]});
+        }
+        await this.updateDropdown();
+        await this.initializeJdk();
+
+        await this.showData('test');
+        this.showData('baseline');
+     }
+    // Get all dropdown values from database
+    async updateDropdown () {
+        await fetch("/api/getTabularDropdown").then(response => response.json()).then((data) => {
+                this.setState({
+                    tabularDropdown: data
+            });
+        });
+    }
+    // Populate dropdown menus with values from state, set value if supplied in url or set to default value
+    generateDropdown (dropdownName, dropdownValues, defaultValue) {
+        let select = document.getElementById(dropdownName);
+        let revertToDefault = false;
+
+        for (const item in dropdownValues){
+            var opt = document.createElement('option');
+            opt.value = dropdownValues[item];
+            opt.innerHTML = dropdownValues[item];
+            select.appendChild(opt);
+        }
+       // Check if url value exists in state, if not go to default
+        if (!(dropdownName in this.state)) {
+            revertToDefault = true;
+        } else {
+            // Check if url value exists in the dropdown options, if not go to default
+            if (dropdownValues.indexOf(this.state[dropdownName]) > -1) {
+                return;
+            }
+            else { revertToDefault = true;
+            }
+       }
+        // Check if default exists in these dropdown options, if not use 1st index in dropdown options
+        if (revertToDefault) {
+            if (dropdownValues.indexOf(defaultValue > -1)) {
+                this.setState({[dropdownName]: defaultValue});
+            }
+            else {
+                this.setState({[dropdownName]: dropdownValues[0]});
+            }
+        }
+    }
+    // Set default values for choosing the JDK including date, version, type and sdk resource if URL has missing information
+    async initializeJdk () {
+        const date = (new Date().getDate()).toString();
+        const month = (new Date().getMonth() + 1).toString(); //Current Month
+        const year = (new Date().getFullYear()).toString(); //Current Year
+        // Assumption: JDK date is in the format of YYYYMMDD in database, example: 20190814
+        const jdkDate = year + ((month.length < 2) ? "0" + month : month) + ((date.length < 2) ? "0" + date : date)
+        
+        /*
+        Each database entry should contain a pipeline name (buildName) which contains the JDK Version and JVM Type.
+        sdkResource in the form of null, releases, nightly, customized or upstream
+        date is in the benchmarkProduct field and in the form of YYYYMMDD
+        Default values are defined in TabularViewConfig.json. Add the optional Jenkins server otherwise will default to first option
+        */
+        this.generateDropdown('testJdkVersion', this.state.tabularDropdown['jdkVersion'], this.state.defaultValues.jdkVersion);
+        this.generateDropdown('testJvmType', this.state.tabularDropdown['jvmType'], this.state.defaultValues.jvmType);
+        this.generateDropdown('testSdkResource', this.state.tabularDropdown['sdkResource'], this.state.defaultValues.testSdkResource);
+        this.generateDropdown('testBuildServer', this.state.tabularDropdown['buildServer'], this.state.defaultValues.jenkinsServer);
+        this.generateDropdown('baselineJdkVersion', this.state.tabularDropdown['jdkVersion'], this.state.defaultValues.jdkVersion);
+        this.generateDropdown('baselineJvmType', this.state.tabularDropdown['jvmType'], this.state.defaultValues.jvmType);
+        this.generateDropdown('baselineSdkResource', this.state.tabularDropdown['sdkResource'], this.state.defaultValues.baselineSdkResource);
+        this.generateDropdown('baselineBuildServer', this.state.tabularDropdown['buildServer'], this.state.defaultValues.jenkinsServer);
+
+        !('testJdkDate' in this.state) && (this.setState({testJdkDate: jdkDate}));
+        !('baselineJdkDate' in this.state) && (this.setState({baselineJdkDate: jdkDate}));
+    }
+    // Handle simple event changes for JDK version, type and sdk resource
+    handleChange(event) {
+        this.setState({
+            [event.target.name]: event.target.value
+        });
+    }
+    // Set the color state and call the filter
+    handleColorFilter (event) {
+        this.setState({
+            colorFilter: event.target.value
+        }, () => {
+        	// Color changed, signal to call benchmark filter first
+            this.colorFilter(true);
+        });
+    }
+ 
+    handleDayChange(selectedDay, modifiers, dayPickerInput) {
+
+        const input = dayPickerInput.getInput();
+        this.setState({
+            selectedDay,
+            isEmpty: !input.value.trim(),
+            isDisabled: modifiers.disabled === true,
+        }, function () {
+            if (this.state.selectedDay !== undefined) {
+                // Transform date to correct format
+                this.dateTransform(this.state.selectedDay.toLocaleDateString(), dayPickerInput.props.dayPickerProps.type);}
+        });
+    }
+
+    setTreeData() {
+        // Set the tree select values for benchmark filter, more information found in https://ant.design/components/tree-select/
+        let newArray = [];
+        this.state.consolidatedData.forEach(function (consolidatedDataObject) {
+            let benchmark = consolidatedDataObject.benchmarkNVM.split(",")[0];
+            let variant = consolidatedDataObject.benchmarkNVM.split(",")[1];
+            let metric = consolidatedDataObject.benchmarkNVM.split(",")[2];
+
+            let benchmarkLevel = {};
+            let variantLevel = {};
+            /*
+            Giving unique values in order to avoid showing metrics for all benchmark variants and metrics. Titles can be same such as Startup time in ms, but their values will be different.
+            By setting specific values for each title, we limit the display to one variant, requiring user to manually select different variants in case one wants to 
+            look up the metric for multiple variants. For example, footprint metric exists in multiple Liberty variants such as DT7, DT3 and AcmeAir.
+            */
+            let metricLevel = {title: metric, value: consolidatedDataObject.benchmarkNVM};
+
+            let benchmarkIndex = newArray.map(function(x) {return x.title; }).indexOf(benchmark);
+
+            // Benchmark Exists
+            if (benchmarkIndex !== -1) {
+                let benchmarkParent = newArray[benchmarkIndex];
+                let variantIndex = benchmarkParent.children.map(function(x) {return x.title; }).indexOf(variant);
+
+                // Variant Exists
+                if (variantIndex !== -1) {
+                    let variantParent = benchmarkParent.children[variantIndex];
+                    variantParent.children.push(metricLevel);
+                    benchmarkParent.children[variantIndex] = variantParent;
+                    newArray[benchmarkIndex] = benchmarkParent;
+                }
+
+                // Variant does not exist
+                else {
+                    variantLevel.title = variant;
+                    variantLevel.value = benchmark + ',' + variant;
+                    variantLevel.children = [metricLevel];
+                    benchmarkParent.children.push(variantLevel);
+                    newArray[benchmarkIndex] = benchmarkParent;
+                }
+            }
+
+            else {
+                benchmarkLevel.title = benchmark;
+                benchmarkLevel.value = benchmark;
+                variantLevel.title = variant;
+                variantLevel.value = benchmark + ',' +variant;
+
+                variantLevel.children = [metricLevel];
+                benchmarkLevel.children = [variantLevel];
+                newArray.push(benchmarkLevel);		
+            }
+        });
+
+        this.setState({treeData: newArray});
+    }
+    // When Submit button clicked, update table and URL
+    handleSubmit(event) {
+        this.showData('test');
+        this.showData('baseline');
+        event.preventDefault();
+        
+        // Update URL with current state
+        const newPath = '/tabularView?testJdkDate=' + this.state.testJdkDate + '&testJvmType=' + this.state.testJvmType + '&testJdkVersion=' + this.state.testJdkVersion
+        + '&testSdkResource=' + this.state.testSdkResource + '&testBuildServer=' + this.state.testBuildServer
+        + '&baselineJdkDate=' + this.state.baselineJdkDate + '&baselineJvmType=' + this.state.baselineJvmType + '&baselineJdkVersion=' + this.state.baselineJdkVersion
+        + '&baselineSdkResource=' + this.state.baselineSdkResource + '&baselineBuildServer=' + this.state.baselineBuildServer;
+
+        window.history.replaceState(null, '', newPath);
+    }
+    // Helper function to get value from benchmark entry
+    handleProp (val, field) {
+        if (val == null) {
+            return "N/A";
+        }
+        else if (field === 'buildUrl') {
+            let urls = {};
+            if ((val['testBuildUrl']) && (val['baselineBuildUrl'])) {
+                urls.testBuildUrl = val['testBuildUrl'];
+                urls.baselineBuildUrl = val['baselineBuildUrl'];
+            }
+            else if (val['testBuildUrl']) {
+                urls.testBuildUrl = val['testBuildUrl'];
+            } else if (val['baselineBuildUrl']) {
+                urls.baselineBuildUrl = val['baselineBuildUrl'];
+            }
+            return urls;	
+        }
+        else {return val[field];}
+    }
+
+    handleLink (urls) {
+    // Calling PerfCompare with Links
+    let url = "perfCompare?";
+    if(urls.hasOwnProperty('testBuildUrl') && urls.hasOwnProperty('baselineBuildUrl')) {
+        url+= 'testID=' + urls.testBuildUrl + '&baselineID=' + urls.baselineBuildUrl;
+    } else if (urls.hasOwnProperty('testBuildUrl')) {
+        url+= 'testID=' + urls.testBuildUrl;
+    } else if (urls.hasOwnProperty('baselineBuildUrl')) {
+        url+= 'baselineID=' + urls.baselineBuildUrl;
+    } else {return;}
+
+    const win = window.open(url, '_blank');
+    win.focus();
+    }
+    // Update table columns when platforms are ticked or unticked
+    onPlatformChange (checkedValues, event) {
+        let newArray = this.state.originalColumns;
+
+        newArray = newArray.filter(column => column.Header === "Benchmark Name" || checkedValues.includes(column.id));
+        this.setState({columns: newArray});
+    }
+    // Update table contents based on which benchmarks are ticked in the benchmark filter
+    onBenchmarkChange = value => {
+        this.setState({benchmarkFilter: value});
+        this.benchmarkFilter(value);
+    }
+    // Date picker format needs to be converted to match the one available in the database entry
+    dateTransform(date, type) {
+        const dateSplit = date.split('/');
+        // Database date format: YYYYMMDD
+        const jdkDate = dateSplit[2] + ((dateSplit[0].length < 2) ? "0" + dateSplit[0] : dateSplit[0]) + ((dateSplit[1].length < 2) ? "0" + dateSplit[1] : dateSplit[1]);
+
+        if (type === 'test') {
+            this.setState({testJdkDate: jdkDate});
+        } else {
+            this.setState({baselineJdkDate: jdkDate});
+        }
+    }
+    // Based on data returned from database, create relevant columns for platforms
+    generateColumns(platforms) {
+        const newArray = [];
+        let column = {
+        Header: 'Benchmark Name',
+        accessor: 'benchmarkNVM',
+        // The three line breaks ensure the benchmark name, variant and metric appear in separate lines
+        Cell: props => <span>{props.value.split(",")[0]} <br/> {props.value.split(",")[1]} <br/> {props.value.split(",")[2]}</span>
+        };
+
+        newArray.push(column);
+
+        for (let i = 0; i < platforms.length; i++) {
+            let platform = platforms[i];
+    	
+            column = {};
+            column.id = platform;
+            column.Header = platform.toUpperCase();
+            column.accessor = d => d.platformsSpecificData[platform];
+            // Each cell needs to display the comparison by default, on hover displays further details
+            column.Cell = props => <Tooltip title={<div >
+                Raw Test Score: {this.handleProp(props.value, 'testScore')} <br/> 
+                Test CI: {this.handleProp(props.value, 'testCI')}  <br/>
+                Test JDK: {this.handleProp(props.value, 'testJdk')}	<br/> 
+                Test Sdk Resource: {this.handleProp(props.value, 'testSdkResource')}	<br/> 
+                Raw Baseline Score: {this.handleProp(props.value, 'baselineScore')} <br/> 
+                Basline CI: {this.handleProp(props.value, 'baselineCI')}  <br/>
+                Baseline JDK: {this.handleProp(props.value, 'baselineJdk')} <br/>
+                Baseline Sdk Resource: {this.handleProp(props.value, 'baselineSdkResource')}
+                </div> }>
+                <span onClick={() => this.handleLink(this.handleProp(props.value, 'buildUrl'))}> {this.handleProp(props.value, 'relativeComparison')} % <br/> {this.handleCI(this.handleProp(props.value, 'totalCI'), this.handleProp(props.value, 'relativeComparison'))} </span></Tooltip>;
+            column.getProps = (state, rowInfo) => (this.handleRegression(this.handleProp(rowInfo.row[platform], 'relativeComparison')));
+            newArray.push(column);
+        }
+        this.setState({columns:newArray, originalColumns: newArray});
+    }
+    // Set cell color based on comparison value
+    handleRegression (val) {
+        let color;
+        if (val === 0) {
+            color = '#ffdbac';}
+        else if ((val <= redFilter[1]) && (val > redFilter[0])) {
+            color = '#cc3232';}
+        else if ((val <= yellowFilter[1]) && (val > yellowFilter[0])) {
+            color =  '#F0F755';}
+        else if (val === 'N/A') {
+            color = 'grey';}
+        else color =  '#2dc937';
+
+        return {
+            style: {
+                fontSize: 25,
+                backgroundColor: color
+            }	
+        }
+    }
+    // Show a warning if the confidence interval exceeds the regression. Closer look at data is necessary to confirm regression.
+    handleCI(totalCI, relativeComparison) {
+        if (relativeComparison == 100 || relativeComparison == 0 || relativeComparison === "N/A") {return;}
+        else if (totalCI * 100 < (Math.abs(relativeComparison - 100) + 0.7)) {return;} 
+        else {
+            return <Icon type="warning" />;
+        }
+    }
+    // Two filters Benchmark and Color. Always call benchmark filter first. If color filter is the first filter, boolean ensures benchmark filter is called first instead
+    colorFilter(firstFilter) {
+    	// Always call benchmark filter first if true
+        if (firstFilter) {
+            this.benchmarkFilter(this.state.benchmarkFilter);}
+        else {
+        	// If set to this.state.consolidated data, ends up changing the original data due to how javascript stores objects inside arrays
+            let newArray = JSON.parse(JSON.stringify(this.state.consolidatedData));
+            let filterRange;
+            // If color filter is set to ALL, do not not apply filter
+            if (this.state.colorFilter === "green") {filterRange = greenFilter;}
+            else if (this.state.colorFilter === "yellow") {filterRange = yellowFilter;}
+            else if (this.state.colorFilter === "red") {filterRange = redFilter;}
+            else {return;}
+
+        for (let i=0; i < this.state.consolidatedData.length; i++) {
+            for (let platform in this.state.consolidatedData[i].platformsSpecificData) {
+            	// Set values to N/A if they are outside the filterRange
+                if ((parseFloat(this.state.consolidatedData[i].platformsSpecificData[platform].relativeComparison) > filterRange[1]) || (parseFloat(this.state.consolidatedData[i].platformsSpecificData[platform].relativeComparison) <= filterRange[0])) {
+                    newArray[i].platformsSpecificData[platform].relativeComparison = 'N/A';
+                }
+            }
+        }
+
+        this.setState({consolidatedData: newArray});
+        }
+    }
+
+    benchmarkFilter(value) {
+        let newArray = [];
+
+        //Always call color filter after applying benchmark filter, if no filter selected return original data
+        if (value.length === 0) {
+            this.setState({
+                consolidatedData: this.state.originalData
+            }, () => {
+            	// Indicate that colorFilter is being called second
+                this.colorFilter(false);
+            });
+        } else {
+            this.state.originalData.forEach(function (element) {
+                let found = false;
+
+                for (let i = 0; i < value.length; i++) {
+                    if (element.benchmarkNVM.indexOf(value[i]) !== -1) {
+                        found = true;
+                    }
+                }
+
+                if (found) {newArray.push(element);}
+            });
+
+            this.setState({
+                consolidatedData: newArray
+            }, () => {
+                this.colorFilter(false);
+            });
+        }
+    }
+    // Enter values in the proper fields before saving to the test/baseline array
+    handleEntry(testResultObject, metric, type) {
+        if (type === 'test') {
+            return {testScore: testResultObject.aggregateInfo[0].metrics[metric].value.mean, 
+                testJdkDate: testResultObject.aggregateInfo[0].benchmarkProduct.split("-")[1],
+                testJdk: testResultObject.aggregateInfo[0].benchmarkProduct,
+                testCI: testResultObject.aggregateInfo[0].metrics[metric].value.CI,
+                testSdkResource: testResultObject.sdkResource,
+                testBuildUrl: testResultObject.buildUrl,
+                relativeComparison: testResultObject.aggregateInfo[0].metrics[metric].value.mean
+            };
+        } else {
+            return {baselineScore: testResultObject.aggregateInfo[0].metrics[metric].value.mean, 
+                baselineJdkDate: testResultObject.aggregateInfo[0].benchmarkProduct.split("-")[1],
+                baselineJdk: testResultObject.aggregateInfo[0].benchmarkProduct,
+                baselineCI: testResultObject.aggregateInfo[0].metrics[metric].value.CI,
+                baselineSdkResource: testResultObject.sdkResource,
+                baselineBuildUrl: testResultObject.buildUrl,
+                relativeComparison: testResultObject.aggregateInfo[0].metrics[metric].value.mean
+            };
+
+        }
+    }
+
+    populateTable(data, type) {
+    	/* Table object format, each entry in the array is an object with two fields benchmarkNVM (benchmark Name Variant Metric) and platformsSpecificData.
+    	platformsSpecificData is an object with each field being a separate platform containing the jdk data such as score, date, CI */
+        const newArray = [];
+        let dataObject = {};
+        let platform;
+        let benchmarkNVM = "";
+        let found = false;
+
+        data.forEach(function (testResultsObject) {
+            platform = testResultsObject.buildName.split("_").slice(4).join('_');
+            for (const metric in testResultsObject.aggregateInfo[0].metrics) {
+                found = false;
+                benchmarkNVM = testResultsObject.aggregateInfo[0].benchmarkName + ',' + testResultsObject.aggregateInfo[0].benchmarkVariant + "," + testResultsObject.aggregateInfo[0].metrics[metric].name;
+
+                for (const currentDataObject in newArray) {
+                	// If benchmark already exists append to it
+                    if (newArray[currentDataObject].benchmarkNVM == benchmarkNVM) {
+                        found = true;
+                        newArray[currentDataObject].platformsSpecificData[platform] = this.handleEntry(testResultsObject, metric, type);
+                        break;
+                    }
+                }
+               // Create a new entry if benchmark name does not exist
+                if (!found) {
+                    dataObject = {};
+                    dataObject.platformsSpecificData = {};
+                    dataObject.benchmarkNVM = testResultsObject.aggregateInfo[0].benchmarkName + ',' + testResultsObject.aggregateInfo[0].benchmarkVariant + ',' + testResultsObject.aggregateInfo[0].metrics[metric].name;
+                    dataObject.platformsSpecificData[platform] = this.handleEntry(testResultsObject, metric, type);
+                    newArray.push(dataObject);	
+                }
+            }
+        }.bind(this));
+        if (type === 'test') {
+            this.setState({testData:newArray});
+        } else {
+            this.setState({baselineData:newArray});	
+        }
+    }
+
+    populateCompTable() {
+    	// Each entry is a combination of the data in testData and baselineData, same format two fields benchmarkName and platforms
+    	// Now platform entries contain information from both the testJdk and the baselineJdk
+        const newArray = [];
+
+        this.state.testData.forEach(function (testDataObject) {
+            let consolidatedDataObject = {};
+            let benchmark = testDataObject.benchmarkNVM.split(",")[0];
+            let variant = testDataObject.benchmarkNVM.split(",")[1];
+            let metric = testDataObject.benchmarkNVM.split(",")[2];
+            consolidatedDataObject.platformsSpecificData = {};
+            consolidatedDataObject.benchmarkNVM = testDataObject.benchmarkNVM;
+
+            let higherBetter;
+            try {
+                if (benchmarkVariantsInfo[benchmark][variant][metric]["higherbetter"] === "t") {
+                    higherBetter = true;
+                } else {
+                    higherBetter = false;
+                }
+            } catch (higherBetterNotFoundError) {
+                higherBetter = true;
+            }
+
+            let matchingDataObject = this.state.baselineData.find( s => s.benchmarkNVM == testDataObject.benchmarkNVM );
+            // Baseline data contains information for the benchmark, comparison possible
+            if (matchingDataObject != null) {
+            Object.keys(testDataObject.platformsSpecificData).forEach(function(platform) {
+            	// Baseline data contains same benchmark and same platform, compare values and store in comparison table
+                if (matchingDataObject.platformsSpecificData.hasOwnProperty(platform)) {
+                    consolidatedDataObject.platformsSpecificData[platform] = {...testDataObject.platformsSpecificData[platform], ...matchingDataObject.platformsSpecificData[platform]};	
+                    if (higherBetter) {
+                        consolidatedDataObject.platformsSpecificData[platform].relativeComparison = Number(testDataObject.platformsSpecificData[platform].testScore * 100 / matchingDataObject.platformsSpecificData[platform].baselineScore).toFixed(2);
+                    } else {
+                        consolidatedDataObject.platformsSpecificData[platform].relativeComparison = Number(matchingDataObject.platformsSpecificData[platform].baselineScore * 100 / testDataObject.platformsSpecificData[platform].testScore).toFixed(2);
+                    }
+                   consolidatedDataObject.platformsSpecificData[platform].totalCI = testDataObject.platformsSpecificData[platform].testCI + matchingDataObject.platformsSpecificData[platform].baselineCI;
+                // Only test data exists for this platform, set comparison table cell value to test data cell value
+                } else {
+                    consolidatedDataObject.platformsSpecificData[platform] = testDataObject.platformsSpecificData[platform];
+                    consolidatedDataObject.platformsSpecificData[platform].relativeComparison = 0;
+                }
+            });
+           // Baseline does not have the benchmark data, set to test data
+            } else {
+                consolidatedDataObject.platformsSpecificData = testDataObject.platformsSpecificData;
+                Object.keys(consolidatedDataObject.platformsSpecificData).map(function(key, index) {
+                    consolidatedDataObject.platformsSpecificData[key].relativeComparison = 0;
+                });
+            }
+        newArray.push(consolidatedDataObject);
+        }.bind(this));
+        // Loop through baseline table and the newly created array to fill the gaps in comparison table
+        this.state.baselineData.forEach(function (baselineDataObject) {
+
+            let matchingDataObject = newArray.find( s => s.benchmarkNVM == baselineDataObject.benchmarkNVM );
+            if (matchingDataObject != null) {
+                Object.keys(baselineDataObject.platformsSpecificData).forEach(function(platform) {
+                    if (!(matchingDataObject.platformsSpecificData.hasOwnProperty(platform))) {
+                        matchingDataObject.platformsSpecificData[platform] = baselineDataObject.platformsSpecificData[platform];
+                        matchingDataObject.platformsSpecificData[platform].relativeComparison = 0;
+                    }
+                });
+            } else {
+                let consolidatedDataObject = {};
+                consolidatedDataObject.platformsSpecificData = baselineDataObject.platformsSpecificData;
+                Object.keys(consolidatedDataObject.platformsSpecificData).map(function(key, index) {
+                    consolidatedDataObject.platformsSpecificData[key].relativeComparison = 0;
+                });
+                consolidatedDataObject.benchmarkNVM = baselineDataObject.benchmarkNVM;
+                newArray.push(consolidatedDataObject);
+        }
+    });
+        // Set the comparison table, and a copy of the original for use with filtering
+        this.setState({consolidatedData:[...newArray], originalData: [...newArray]});
+        this.setTreeData();
+        this.benchmarkFilter(this.state.benchmarkFilter);
+
+    }
+    // Main function to fetch data from backend and call the function to populate the displayed table
+    showData = async (type) => {
+        let tabularData;
+        if (type === 'test') {
+            tabularData = await fetch( `/api/getTabularData?jdkVersion=${this.state.testJdkVersion}&jvmType=${this.state.testJvmType}&jdkDate=${this.state.testJdkDate}
+            &sdkResource=${this.state.testSdkResource}&buildServer=${this.state.testBuildServer}`, {
+                method: 'get'
+            } );
+        } else {
+            tabularData = await fetch( `/api/getTabularData?jdkVersion=${this.state.baselineJdkVersion}&jvmType=${this.state.baselineJvmType}&jdkDate=${this.state.baselineJdkDate}
+            &sdkResource=${this.state.baselineSdkResource}&buildServer=${this.state.baselineBuildServer}`, {
+                method: 'get'
+                } );
+        }
+        const info = await tabularData.json();
+        const platformArray = [...new Set([...this.state.platforms,...(info.pop().map(platform => platform.split("_").slice(4).join('_')))])];
+
+        this.setState({platforms:platformArray});
+
+        this.generateColumns(this.state.platforms);
+    
+        const platformFilter = [];
+        for (let platform in this.state.platforms) {
+            platformFilter.push({label: this.state.platforms[platform], value: this.state.platforms[platform], disabled: false});
+        }
+        this.setState({platformFilter: platformFilter});
+        this.populateTable(info, type);
+        this.populateCompTable();
+    }
+
+    render() {
+        const tProps = {
+            value: this.state.benchmarkFilter,
+            onChange: this.onBenchmarkChange,
+            treeCheckable: true,
+            showCheckedStrategy: SHOW_PARENT,
+            searchPlaceholder: "Please choose the benchmarks to view",
+            style: {
+                 width: 1000
+            }
+        };
+        return (
+            <div>
+                <div className="row">
+                    <div className="column" style={{fontSize:20, fontWeight:'bold'}}> Parameters <br/> </div>
+                    <div className="column" style={{fontSize:20, fontWeight:'bold'}}> Test <br/> </div>
+                    <div className="column" style={{fontSize:20, fontWeight:'bold'}}> Baseline <br/> </div>
+            </div>
+            <div className="row">
+                    <div className="column" style={colStyle}> JDK Date <br/> </div>
+                    <div className="column"> 
+                        <DayPickerInput
+                            onDayChange={this.handleDayChange}
+                            value={this.state.testJdkDate}
+                            overlayComponent={CustomOverlay}
+                            dayPickerProps={{
+                                todayButton: 'Today',
+                                type: 'test'
+                            }}
+                            keepFocus={false}
+                        /> 
+            <Tooltip placement="topRight" title="Table will contain latest results from all builds dated before the chosen date regardless of when the benchmark was run.">
+                <Icon type="question-circle" />
+            </Tooltip></div>
+            <div className="column"> 
+                <DayPickerInput
+                    onDayChange={this.handleDayChange}
+                    value={this.state.baselineJdkDate}
+                    overlayComponent={CustomOverlay}
+                    dayPickerProps={{
+                        todayButton: 'Today',
+                        type: 'baseline'
+                    }}
+                    keepFocus={false}
+                /> 
+            <Tooltip placement="topRight" title="Table will contain latest results from all builds dated before the chosen date regardless of when the benchmark was run.">
+                <Icon type="question-circle" />
+            </Tooltip></div>
+        </div>
+        <div className="row">
+            <div className="column" style={colStyle}> JDK Version <br/> </div>
+            <div className="column"> <select id="testJdkVersion" name="testJdkVersion" className="select-css" value={this.state.testJdkVersion} onChange={this.handleChange.bind(this)}>
+            </select></div>
+            <div className="column"> <select id="baselineJdkVersion" name="baselineJdkVersion" className="select-css" value={this.state.baselineJdkVersion} onChange={this.handleChange.bind(this)}>
+            </select></div>
+        </div>
+        <div className="row">
+            <div className="column" style={colStyle}> JVM Type <br/> </div>
+            <div className="column"> <select id="testJvmType" name="testJvmType" className="select-css" value={this.state.testJvmType} onChange={this.handleChange.bind(this)}>
+            </select></div>
+            <div className="column"> <select id="baselineJvmType" name="baselineJvmType" className="select-css" value={this.state.baselineJvmType} onChange={this.handleChange.bind(this)}>
+            </select></div>
+        </div>
+        <div className="row">
+            <div className="column" style={colStyle}> SDK Resource <br/> </div>
+            <div className="column"> <select id="testSdkResource" name="testSdkResource" className="select-css" value={this.state.testSdkResource} onChange={this.handleChange.bind(this)}>
+            </select></div>
+            <div className="column"> <select id="baselineSdkResource" name="baselineSdkResource" className="select-css" value={this.state.baselineSdkResource} onChange={this.handleChange.bind(this)}>
+            </select></div>
+        <div className="row">
+            <div className="column" style={colStyle}> Jenkins Server <br/> </div>
+            <div className="column"> <select id="testBuildServer" name="testBuildServer" className="select-css" value={this.state.testBuildServer} onChange={this.handleChange.bind(this)}>
+            </select></div>
+            <div className="column"> <select id="baselineBuildServer" name="baselineBuildServer" className="select-css" value={this.state.baselineBuildServer} onChange={this.handleChange.bind(this)}>
+            </select></div>
+        </div>
+        </div>
+
+        <Button type="primary" onClick={this.handleSubmit.bind(this)}>
+            Submit
+        </Button>
+
+        <Collapse>
+            <Panel header='Filters' key="1"> <label> Choose Platforms: </label> <Checkbox.Group options={this.state.platformFilter} onChange={this.onPlatformChange.bind(this)} />
+                <br/><TreeSelect treeData={this.state.treeData} {...tProps} /> <br/>
+                <span> Please choose the color filter: </span><select name="colorFilter" value={this.state.colorFilter} onChange={this.handleColorFilter.bind(this)}>
+                    <option value="all">All</option>
+                    <option value="green">Green</option>
+                    <option value="red">Red</option>
+                    <option value="yellow">Yellow</option>
+                  </select>
+            </Panel>
+    </Collapse> 
+        <ReactTable
+            data={this.state.consolidatedData}
+            columns={this.state.columns}
+            showPaginationBottom={false}
+            showPageSizeOptions={false}
+            minRows={0}
+        />
+        <br/>
+        <ReactTable
+            data={legendRows}
+            columns={legendColumns}        
+            showPagination={false}
+            showPaginationTop={false}
+            showPaginationBottom={false}
+            showPageSizeOptions={false}
+            minRows={0}
+            getTrProps={(state, rowInfo, column) => {
+                return {
+                    style: {
+                        background: rowInfo.row._original.color,
+                    fontSize: 20
+                    }
+                };
+            }}
+        />
+        </div>
+        );
+    }
+
+}

--- a/test-result-summary-client/src/TabularView/TabularViewConfig.json
+++ b/test-result-summary-client/src/TabularView/TabularViewConfig.json
@@ -1,0 +1,7 @@
+{
+    "jdkVersion" : "openjdk8", 
+    "jvmType" : "j9", 
+    "testSdkResource" : "nightly", 
+    "baselineSdkResource" : "releases",
+    "jenkinsServer" : "https://CustomJenkinsServer.company.com"
+}

--- a/test-result-summary-client/src/TabularView/index.js
+++ b/test-result-summary-client/src/TabularView/index.js
@@ -1,0 +1,1 @@
+export { default as TabularView } from "./TabularView";


### PR DESCRIPTION
- Closes AdoptOpenJDK#37
- Current filters: benchmark, platform, cell color
- Allows comparison between different jdk versions and types
- Cell on click redirects to Perf Compare
- Perf Compare changed to fill in values from URL on load
- Added sdkResource to parser, will be added as field to database

Co-authored-by: Piyush Gupta piyush286@gmail.com

Signed-off-by: Awsaf Arefin Sakif <awsaf.sakif@ibm.com>