### PR TITLE
Disable Echo of Executed Bash Commands in Jenkins Output

### DIFF
--- a/PerfNext/app/apis/BenchEngine/parser.js
+++ b/PerfNext/app/apis/BenchEngine/parser.js
@@ -409,7 +409,7 @@ function parseDefinition(raw_definition, callback){
 			}
 
 			fs.readFile('logo.txt', 'utf8', function(err, contents) {
-				generatedOutput = contents + '\n' +  generatedOutput;
+				generatedOutput = '#!/bin/bash +x \n' + contents + '\n' +  generatedOutput;
 
 				callback(generatedOutput);
 			});

--- a/PerfNext/setup.sh
+++ b/PerfNext/setup.sh
@@ -1,3 +1,4 @@
+#!/bin/bash +x
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
- Disabled echo of executed commands in Jenkins in order to reduce the output size, making the console output more easier to read and parse

Signed-off-by: Piyush Gupta <piyush286@gmail.com>