### PR TITLE
Enhancements for Tabular View & Benchmark Parser

### DIFF
--- a/TestResultSummaryService/parsers/BenchmarkMetricRouter.js
+++ b/TestResultSummaryService/parsers/BenchmarkMetricRouter.js
@@ -18,7 +18,8 @@ const BenchmarkMetricRouter = {
         "17dev-4way-0-256-qs": "LibertyStartup"
     },
     "ILOG_WODM": {
-        "881-4way-Seg5FastpathRVEJB": "ILOG_WODM"
+        "881-4way-Seg5FastpathRVEJB": "ILOG_WODM",
+        "881-4way-Seg300RulesFastpathRVEJB": "ILOG_WODM"
     },
     "SPECjbb2015": {
         "multi_2grp_gencon": "SPECjbb2015"

--- a/TestResultSummaryService/perf/DataManagerAggregate.js
+++ b/TestResultSummaryService/perf/DataManagerAggregate.js
@@ -5,11 +5,11 @@ const ObjectID = require( 'mongodb' ).ObjectID;
 class DataManagerAggregate {
     static aggDataCollect(childBuild) {
         const benchmarkMetricsCollection = {};
-        let name, variant, product;
+        let name, variant, jdkBuildDate;
         if (Array.isArray(childBuild.tests) && childBuild.tests.length > 0 ) {
             name = childBuild.tests[0].benchmarkName;
             variant = childBuild.tests[0].benchmarkVariant;
-            product = childBuild.tests[0].benchmarkProduct;
+            jdkBuildDate = childBuild.tests[0].jdkDate;
             for ( let {testData} of childBuild.tests){
                 if ( Array.isArray(testData.metrics) ) {
                     for ( let {name, value} of testData.metrics ){
@@ -22,12 +22,12 @@ class DataManagerAggregate {
                 }
             }
         }
-        return {name, variant, product, benchmarkMetricsCollection};
+        return {name, variant, jdkBuildDate, benchmarkMetricsCollection};
     }
 
-    static async updateBuildWithAggregateInfo(id, testResultsDB, name, variant, product, metricsCollection) {
+    static async updateBuildWithAggregateInfo(id, testResultsDB, name, variant, jdkBuildDate, metricsCollection) {
         // calculate the aggregate data
-        if (name != null && variant != null && product != null && metricsCollection != null) {
+        if (name != null && variant != null && jdkBuildDate != null && metricsCollection != null) {
             const aggData = [];
             const aggregateInfo = [];
             Object.keys( metricsCollection ).forEach( function(key) {
@@ -51,7 +51,7 @@ class DataManagerAggregate {
             aggregateInfo.push({
                 benchmarkName: name,
                 benchmarkVariant: variant,
-                benchmarkProduct: product,
+                jdkDate: jdkBuildDate,
                 metrics: aggData
             });
             const criteria = { _id: new ObjectID( id ) };

--- a/TestResultSummaryService/plugins/DataManagerPerf.js
+++ b/TestResultSummaryService/plugins/DataManagerPerf.js
@@ -4,7 +4,7 @@ module.exports.onBuildDone = async (task, { testResultsDB, logger }) => {
     logger.debug("onBuildDone", task.buildName);
     if ( task.type === "Perf" ) {
         if ( !task.aggregateInfo ) {
-            let benchmarkName, benchmarkVariant, benchmarkProduct;
+            let benchmarkName, benchmarkVariant, jdkDate;
             const metricsCollection = {};
             if ( task.hasChildren ) {
                 // parent node.
@@ -13,20 +13,20 @@ module.exports.onBuildDone = async (task, { testResultsDB, logger }) => {
                 //loop into the child build list
                 for ( let childBuild of childBuildList ) {
                     //loop into each child's tests info.
-                    const {name, variant, product, benchmarkMetricsCollection} = DataManagerAggregate.aggDataCollect(childBuild)
-                    if (name === null || product === null || product === null || benchmarkMetricsCollection === null ) {
+                    const {name, variant, jdkBuildDate, benchmarkMetricsCollection} = DataManagerAggregate.aggDataCollect(childBuild)
+                    if (name === null || variant === null || jdkBuildDate === null || benchmarkMetricsCollection === null ) {
                         // failed child build, continue with other children
                         continue;
                     } else {
-                        if (benchmarkName === undefined && benchmarkVariant === undefined && benchmarkProduct === undefined) {
+                        if (benchmarkName === undefined && benchmarkVariant === undefined && jdkDate === undefined) {
                             benchmarkName = name;
                             benchmarkVariant = variant;
-                            benchmarkProduct = product;
-                        } else if ( name != benchmarkName || variant != benchmarkVariant || product != benchmarkProduct ){
+                            jdkDate = jdkBuildDate;
+                        } else if ( name != benchmarkName || variant != benchmarkVariant || jdkBuildDate != jdkDate ){
                             //children's builds information are not the same
                             benchmarkName = null;
                             benchmarkVariant = null;
-                            benchmarkProduct = null;
+                            jdkDate = null;
                             metricsCollection = null;
                             break;
                         }
@@ -43,11 +43,11 @@ module.exports.onBuildDone = async (task, { testResultsDB, logger }) => {
                     }
                 }
                 // update aggregateInfo in the database.
-                await DataManagerAggregate.updateBuildWithAggregateInfo(task._id, testResultsDB, benchmarkName, benchmarkVariant, benchmarkProduct, metricsCollection);
+                await DataManagerAggregate.updateBuildWithAggregateInfo(task._id, testResultsDB, benchmarkName, benchmarkVariant, jdkDate, metricsCollection);
             } else {
                 // not a parent node.
-                const {name, variant, product, benchmarkMetricsCollection} = DataManagerAggregate.aggDataCollect(task)
-                await DataManagerAggregate.updateBuildWithAggregateInfo(task._id, testResultsDB, name, variant, product, benchmarkMetricsCollection);
+                const {name, variant, jdkBuildDate, benchmarkMetricsCollection} = DataManagerAggregate.aggDataCollect(task)
+                await DataManagerAggregate.updateBuildWithAggregateInfo(task._id, testResultsDB, name, variant, jdkBuildDate, benchmarkMetricsCollection);
             }
         }
     }

--- a/TestResultSummaryService/routes/getTabularData.js
+++ b/TestResultSummaryService/routes/getTabularData.js
@@ -2,7 +2,7 @@ const { TestResultsDB, ObjectID } = require( '../Database' );
 
 function exceedDate(jdkDate) {
     return function(element) {
-       return parseInt(element.aggregateInfo[0].benchmarkProduct.slice(-8)) <= parseInt(jdkDate);
+    	return parseInt(element.aggregateInfo[0].jdkDate) <= parseInt(jdkDate);
     }
 }
 
@@ -48,16 +48,16 @@ module.exports = async ( req, res ) => {
         let benchmarkQuery;
         // Return all entries that match the current benchmark and platform
         for (item in platforms) {
-            benchmarkQuery = {$and: [{ buildName: { $regex : platforms[item] }, sdkResource: sdkResourceQuery}, { aggregateInfo: { $elemMatch: { benchmarkName: benchmarks[benchmarkIndex] }}}
+            benchmarkQuery = {$and: [{ buildName: { $regex : platforms[item] }}, { tests: { $elemMatch: { sdkResource: sdkResourceQuery }}}, { aggregateInfo: { $elemMatch: { benchmarkName: benchmarks[benchmarkIndex] }}}
             ] };
             const result = await db.getData(benchmarkQuery).toArray();
 
             // Remove all entries whose build date exceeds the chosen date
             const exceedFilter = result.filter(exceedDate(req.query.jdkDate));
             // Setting the latest build date from the available dates
-            const latestDate = Math.max.apply(Math, exceedFilter.map(function(o) { return parseInt(o.aggregateInfo[0].benchmarkProduct.slice(-8)); }));
+            const latestDate = Math.max.apply(Math, exceedFilter.map(function(o) { return parseInt(o.aggregateInfo[0].jdkDate); }));
             // Remove all runs that are not the latest
-            const dateFilter = exceedFilter.filter(entry => parseInt(entry.aggregateInfo[0].benchmarkProduct.slice(-8)) === latestDate);
+            const dateFilter = exceedFilter.filter(entry => parseInt(entry.aggregateInfo[0].jdkDate) === latestDate);
             const latest = Math.max.apply(Math, dateFilter.map(function(o) { return o.timestamp; }));
             // Keep the latest build with the latest timestamp
             const latestRun = dateFilter.find(function(o){ return o.timestamp == latest; })

--- a/TestResultSummaryService/routes/getTabularDropdown.js
+++ b/TestResultSummaryService/routes/getTabularDropdown.js
@@ -11,11 +11,12 @@ module.exports = async ( req, res ) => {
         {
             $match: query
         },
+        {$unwind: "$tests"},
         {$group :
-       {
+        {
           _id:0,
           buildNames: {$addToSet: '$buildName'},
-          sdkResource: {$addToSet: '$sdkResource'},
+          sdkResource: {$addToSet: '$tests.sdkResource'},
           buildServer: {$addToSet: '$url'},
     }}
     ] );

--- a/test-result-summary-client/package-lock.json
+++ b/test-result-summary-client/package-lock.json
@@ -6950,7 +6950,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
     "get-value": {
@@ -7982,7 +7982,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
     },
     "is-path-cwd": {
@@ -11478,7 +11478,7 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
     },
     "pinkie": {
@@ -15489,7 +15489,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
         "ansi-regex": "^2.0.0"
@@ -15515,7 +15515,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-indent": {
@@ -15852,7 +15852,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
@@ -17126,7 +17126,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "^1.0.1",

--- a/test-result-summary-client/src/Dashboard/Widgets/Graph/DayTrader3.jsx
+++ b/test-result-summary-client/src/Dashboard/Widgets/Graph/DayTrader3.jsx
@@ -83,20 +83,20 @@ export default class DayTrader3 extends Component {
             if ( t.buildResult !== "SUCCESS" ) return;
             // TODO: current code only considers one interation. This needs to be updated
             if ( t.tests[0].testData && t.tests[0].testData.metrics && t.tests[0].testData.metrics.length > 0 ) {
-                const JDKBuildTimeConvert = t.tests[0].testData.jdkBuildDateUnixTime;
+                const jdkDate = t.tests[0].jdkDate;
                 if ( !t.tests[0].testData.metrics[0].value
                     || t.tests[0].testData.metrics[0].value.length === 0
                     || t.tests[0].testData.metrics[0].name !== "Throughput" ) {
                     return;
                 }
-                resultsByJDKBuild[JDKBuildTimeConvert] = resultsByJDKBuild[JDKBuildTimeConvert] || [];
-                resultsByJDKBuild[JDKBuildTimeConvert].push( {
+                resultsByJDKBuild[jdkDate] = resultsByJDKBuild[jdkDate] || [];
+                resultsByJDKBuild[jdkDate].push( {
                     globalThroughput: t.tests[0].testData.metrics[0].value[0],
                     additionalData: {
                         testId: t.tests[0]._id,
                         buildName: t.buildName,
                         buildNum: t.buildNum,
-                        javaVersion: t.tests[0].testData.javaVersion,
+                        javaVersion: t.tests[0].javaVersion,
                     },
                 } );
             }

--- a/test-result-summary-client/src/Dashboard/Widgets/Graph/ODM.jsx
+++ b/test-result-summary-client/src/Dashboard/Widgets/Graph/ODM.jsx
@@ -84,7 +84,7 @@ export default class ODM extends Component {
 
             // TODO: current code only considers one interation. This needs to be updated
             if ( t.tests[0].testData && t.tests[0].testData.metrics && t.tests[0].testData.metrics.length > 0 ) {
-                const JDKBuildTimeConvert = t.tests[0].testData.jdkBuildDateUnixTime;
+                const jdkDate = t.tests[0].jdkDate;
                 if ( !t.tests[0].testData.metrics[0].value
                     || t.tests[0].testData.metrics[0].value.length === 0
                     || t.tests[0].testData.metrics[0].name !== "Global Throughput" ) {
@@ -93,15 +93,15 @@ export default class ODM extends Component {
                 if(!resultsByJDKBuild[t.buildName]) {
                     resultsByJDKBuild[t.buildName] = {};
                 }
-                if(JDKBuildTimeConvert) {
-                    resultsByJDKBuild[t.buildName][JDKBuildTimeConvert] = resultsByJDKBuild[JDKBuildTimeConvert] || [];
-                    resultsByJDKBuild[t.buildName][JDKBuildTimeConvert].push( {
+                if(jdkDate) {
+                    resultsByJDKBuild[t.buildName][jdkDate] = resultsByJDKBuild[jdkDate] || [];
+                    resultsByJDKBuild[t.buildName][jdkDate].push( {
                         globalThroughput: t.tests[0].testData.metrics[0].value[0],
                         additionalData: {
                             testId: t.tests[0]._id,
                             buildName: t.buildName,
                             buildNum: t.buildNum,
-                            javaVersion: t.tests[0].testData.javaVersion,
+                            javaVersion: t.tests[0].javaVersion,
                         },
                     } );
                 }

--- a/test-result-summary-client/src/Dashboard/Widgets/Graph/SPECjbb2015.jsx
+++ b/test-result-summary-client/src/Dashboard/Widgets/Graph/SPECjbb2015.jsx
@@ -107,7 +107,7 @@ export default class SPECjbb2015 extends Component {
 
             // TODO: current code only considers one interation. This needs to be updated
             if ( t.tests[0].testData && t.tests[0].testData.metrics && t.tests[0].testData.metrics.length === 2 ) {
-                const JDKBuildTimeConvert = t.tests[0].testData.jdkBuildDateUnixTime;
+                const jdkDate = t.tests[0].jdkDate;
                 let maxjOPS = null;
                 let criticaljOPS = null;
                 for ( let i = 0; i < t.tests[0].testData.metrics.length; i++ ) {
@@ -121,15 +121,15 @@ export default class SPECjbb2015 extends Component {
                 if ( !maxjOPS || !criticaljOPS ) {
                     return;
                 }
-                resultsByJDKBuild[JDKBuildTimeConvert] = resultsByJDKBuild[JDKBuildTimeConvert] || [];
-                resultsByJDKBuild[JDKBuildTimeConvert].push( {
+                resultsByJDKBuild[jdkDate] = resultsByJDKBuild[jdkDate] || [];
+                resultsByJDKBuild[jdkDate].push( {
                     maxjOPS,
                     criticaljOPS,
                     additionalData: {
                         testId: t.tests[0]._id,
                         buildName: t.buildName,
                         buildNum: t.buildNum,
-                        javaVersion: t.tests[0].testData.javaVersion,
+                        javaVersion: t.tests[0].javaVersion,
                     },
                 } );
             }

--- a/test-result-summary-client/src/PerfCompare/PerfCompare.jsx
+++ b/test-result-summary-client/src/PerfCompare/PerfCompare.jsx
@@ -443,8 +443,8 @@ export default class PerfCompare extends Component {
             curVariantData = {};
             curVariantData["benchmark"] = parsedVariantsBaseline.benchmark;
             curVariantData["variant"] = parsedVariantsBaseline.variant;
-            curVariantData["baselineProduct"] = parsedVariantsBaseline.product;
-            curVariantData["testProduct"] = parsedVariantsTest.product;
+            curVariantData["baselineJdkDate"] = parsedVariantsBaseline.jdkDate;
+            curVariantData["testJdkDate"] = parsedVariantsTest.jdkDate;
             curVariantData["summary"] = "";
             curVariantData["baselineMachine"] = parsedVariantsBaseline.machine;
             curVariantData["testMachine"] = parsedVariantsTest.machine;
@@ -635,11 +635,11 @@ export default class PerfCompare extends Component {
                         Variant: {x.variant}
                     </h3>
 
-                    Baseline Product: {x.baselineProduct} 
+                    Baseline JDK Date: {x.baselineJdkDate} 
                     <Divider type="vertical" />
                     Baseline Machine: {x.baselineMachine}
                     <Divider type="vertical" />
-                    Test Product: {x.testProduct}
+                    Test JDK Date: {x.testJdkDate}
                     <Divider type="vertical" />
                     Test Machine: {x.testMachine}<br />
                     

--- a/test-result-summary-client/src/PerfCompare/lib/ExtractRelevantJenkinsTestResults.js
+++ b/test-result-summary-client/src/PerfCompare/lib/ExtractRelevantJenkinsTestResults.js
@@ -22,7 +22,7 @@ export default class ExtractRelevantJenkinsTestResults {
                 // new variant
                 if (parsedVariantsCommon[curVariantObjectId] === undefined) {
                     parsedVariantsCommon[curVariantObjectId] = {
-                        product: aggregateInfo.benchmarkProduct,
+                        jdkDate: aggregateInfo.jdkDate,
                         benchmark: aggregateInfo.benchmarkName,
                         variant: aggregateInfo.benchmarkVariant,
                         machine: testInfo.machine,

--- a/test-result-summary-client/src/TabularView/TabularView.jsx
+++ b/test-result-summary-client/src/TabularView/TabularView.jsx
@@ -137,7 +137,7 @@ export default class TabularView extends Component {
        }
         // Check if default exists in these dropdown options, if not use 1st index in dropdown options
         if (revertToDefault) {
-            if (dropdownValues.indexOf(defaultValue > -1)) {
+            if (dropdownValues.indexOf(defaultValue) > -1) {
                 this.setState({[dropdownName]: defaultValue});
             }
             else {
@@ -156,7 +156,7 @@ export default class TabularView extends Component {
         /*
         Each database entry should contain a pipeline name (buildName) which contains the JDK Version and JVM Type.
         sdkResource in the form of null, releases, nightly, customized or upstream
-        date is in the benchmarkProduct field and in the form of YYYYMMDD
+        date is in the jdkDate field and in the form of YYYYMMDD
         Default values are defined in TabularViewConfig.json. Add the optional Jenkins server otherwise will default to first option
         */
         this.generateDropdown('testJdkVersion', this.state.tabularDropdown['jdkVersion'], this.state.defaultValues.jdkVersion);
@@ -351,13 +351,13 @@ export default class TabularView extends Component {
             column.accessor = d => d.platformsSpecificData[platform];
             // Each cell needs to display the comparison by default, on hover displays further details
             column.Cell = props => <Tooltip title={<div >
-                Raw Test Score: {this.handleProp(props.value, 'testScore')} <br/> 
+                Test Raw Score: {this.handleProp(props.value, 'testScore')} <br/> 
                 Test CI: {this.handleProp(props.value, 'testCI')}  <br/>
-                Test JDK: {this.handleProp(props.value, 'testJdk')}	<br/> 
+                Test JDK Date: {this.handleProp(props.value, 'testJdkDate')}	<br/> 
                 Test Sdk Resource: {this.handleProp(props.value, 'testSdkResource')}	<br/> 
-                Raw Baseline Score: {this.handleProp(props.value, 'baselineScore')} <br/> 
-                Basline CI: {this.handleProp(props.value, 'baselineCI')}  <br/>
-                Baseline JDK: {this.handleProp(props.value, 'baselineJdk')} <br/>
+                Baseline Raw Score: {this.handleProp(props.value, 'baselineScore')} <br/> 
+                Baseline CI: {this.handleProp(props.value, 'baselineCI')}  <br/>
+                Baseline JDK Date: {this.handleProp(props.value, 'baselineJdkDate')} <br/>
                 Baseline Sdk Resource: {this.handleProp(props.value, 'baselineSdkResource')}
                 </div> }>
                 <span onClick={() => this.handleLink(this.handleProp(props.value, 'buildUrl'))}> {this.handleProp(props.value, 'relativeComparison')} % <br/> {this.handleCI(this.handleProp(props.value, 'totalCI'), this.handleProp(props.value, 'relativeComparison'))} </span></Tooltip>;
@@ -457,8 +457,7 @@ export default class TabularView extends Component {
     handleEntry(testResultObject, metric, type) {
         if (type === 'test') {
             return {testScore: testResultObject.aggregateInfo[0].metrics[metric].value.mean, 
-                testJdkDate: testResultObject.aggregateInfo[0].benchmarkProduct.split("-")[1],
-                testJdk: testResultObject.aggregateInfo[0].benchmarkProduct,
+                testJdkDate: testResultObject.aggregateInfo[0].jdkDate,
                 testCI: testResultObject.aggregateInfo[0].metrics[metric].value.CI,
                 testSdkResource: testResultObject.sdkResource,
                 testBuildUrl: testResultObject.buildUrl,
@@ -466,8 +465,7 @@ export default class TabularView extends Component {
             };
         } else {
             return {baselineScore: testResultObject.aggregateInfo[0].metrics[metric].value.mean, 
-                baselineJdkDate: testResultObject.aggregateInfo[0].benchmarkProduct.split("-")[1],
-                baselineJdk: testResultObject.aggregateInfo[0].benchmarkProduct,
+                baselineJdkDate: testResultObject.aggregateInfo[0].jdkDate,
                 baselineCI: testResultObject.aggregateInfo[0].metrics[metric].value.CI,
                 baselineSdkResource: testResultObject.sdkResource,
                 baselineBuildUrl: testResultObject.buildUrl,


### PR DESCRIPTION
Related to https://github.com/AdoptOpenJDK/openjdk-test-tools/issues/136 https://github.com/AdoptOpenJDK/openjdk-tests/issues/1144 https://github.com/AdoptOpenJDK/openjdk-test-tools/issues/37

Tabular View Changes
	- Enabled the setting of JDK date (i.e. benchmarkProduct) to be dynamic instead of expecting the launch agents such as PerfNext or TestKitGen to set it.
		○ JDK date is used on Tabular View to show the data of latest baseline and test builds before that JDK date.
	- Updated the Tabular View query for fetching unique build names, sdk resource and build servers, options that are displayed for choosing desired baseline or test builds for comparison
		○ Query didn't have the correct SDK resource location.
	- Resolved the issue of Tabular View incorrectly setting states for dropdown options
	- Fixed the Tabular View query for getting the filtered data by updating the SDK resource location

Benchmark Parser Changes
	- Enable the parsing of some benchmarks such Liberty under Adopt openjdk-tests repo to be parsed by TRSS. This design to be extended further in future PRs to allow parsing of other benchmarks as well.
	- Simplied perf parser regexes to get various benchmark info such as benchmark name, variant and JDK info
		○ Removed some constraints so that all info can be parsed without being affected by Jenkins timestamps
	- Updated the Java version regex for Open builds
	- Added extra regex check for parent builds in order to avoid TRSS from considering a perf build from Adopt as a test build. Example of an Adopt perf pipeline name (https://ci.adoptopenjdk.net/view/Test_perf/): Test_openjdk8_j9_sanity.perf_x86-64_linux.
	- Enabled parsing for ODM 300 Ruleset

Signed-off-by: Piyush Gupta <piyush286@gmail.com>