### PR TITLE
Updated TabularView to handle one/more benchmarks in Adopt Perf Builds

### DIFF
--- a/TestResultSummaryService/routes/getTabularData.js
+++ b/TestResultSummaryService/routes/getTabularData.js
@@ -48,7 +48,7 @@ module.exports = async ( req, res ) => {
         let benchmarkQuery;
         // Return all entries that match the current benchmark and platform
         for (item in platforms) {
-            benchmarkQuery = {$and: [{ buildName: { $regex : platforms[item] }}, { tests: { $elemMatch: { sdkResource: sdkResourceQuery }}}, { aggregateInfo: { $elemMatch: { benchmarkName: benchmarks[benchmarkIndex] }}}
+            benchmarkQuery = {$and: [{ buildName: { $regex : platforms[item] }}, { tests: { $elemMatch: { benchmarkName: benchmarks[benchmarkIndex] }}}, { aggregateInfo: { $elemMatch: { benchmarkName: benchmarks[benchmarkIndex] }}}
             ] };
             const result = await db.getData(benchmarkQuery).toArray();
 


### PR DESCRIPTION
#136 #173 
- Updated TabularView to display one or more benchmarks after the new design of multiple benchmarks applied in aggregateInfo.

Signed-off-by: sophiaxu0424 <xuminghong0424@gmail.com>