### PR TITLE
Performance enhancement

### DIFF
--- a/test-result-summary-client/src/Build/TopLevelBuildTable.jsx
+++ b/test-result-summary-client/src/Build/TopLevelBuildTable.jsx
@@ -1,0 +1,220 @@
+import React, { Component } from 'react';
+import { Icon, Table, Tooltip } from 'antd';
+import { Link } from 'react-router-dom';
+import { params } from '../utils/query';
+import BuildLink from './BuildLink';
+
+const pageSize = 5;
+export default class TopLevelBuildTable extends Component {
+
+    state = {
+        currentPage: 1,
+        buildInfo: [],
+    };
+
+    async componentDidMount() {
+        await this.updateData();
+    }
+
+    async componentDidUpdate(prevProps, prevState) {
+        if (prevProps.url !== this.props.url) {
+            await this.updateData();
+        }
+
+        if (prevState.currentPage !== this.state.currentPage) {
+            await this.updateTotals();
+        }
+    }
+
+    async updateData() {
+        const { buildName, url } = this.props;
+        const fetchBuild = await fetch(`/api/getBuildHistory?buildName=${buildName}&url=${url}`, {
+            method: 'get'
+        });
+        const builds = await fetchBuild.json();
+
+        const buildInfo = builds.map(build => ({
+            key: build.buildUrl,
+            build: build,
+            date: build.timestamp ? new Date(build.timestamp).toLocaleString() : null,
+            startBy: build.startBy ? build.startBy : null,
+            jenkins: build,
+        }));
+        this.setState({ buildInfo });
+
+        await this.updateTotals();
+    }
+
+    async updateTotals() {
+        let { buildInfo, currentPage } = this.state;
+        if (buildInfo) {
+            const { buildName, url } = this.props;
+            // only query getTotals if buildInfo does not have the data
+            const i = pageSize * (currentPage - 1);
+
+            await Promise.all(buildInfo.slice(i, pageSize * currentPage).map(async build => {
+                if (build.totals) return;
+                const fetchBuild = await fetch(`/api/getTotals?buildName=${buildName}&url=${url}&buildNum=${build.build.buildNum}`, {
+                    method: 'get'
+                });
+                const totals = await fetchBuild.json();
+                build.totals = totals;
+            }));
+            this.forceUpdate();
+        }
+    }
+
+    onChange = page => {
+        this.setState({
+            currentPage: page,
+        });
+    };
+
+    render() {
+        const { buildInfo } = this.state;
+        const { buildName, url, type } = this.props;
+        if (buildInfo) {
+            const renderFvTestBuild = (value, row, index) => {
+                if (value && value.buildNum) {
+                    let icon = "";
+                    if (value.status !== "Done") {
+                        icon = <Icon type="loading" style={{ fontSize: 16, color: '#DAA520' }} />;
+                        value.buildResult = "PROGRESSING"
+                    } else if (value.buildResult === "SUCCESS") {
+                        icon = <Icon type="check" style={{ fontSize: 16, color: '#2cbe4e' }} />;
+                    } else if (value.buildResult === "FAILURE") {
+                        icon = <Icon type="close" style={{ fontSize: 16, color: '#f50' }} />;
+                    } else {
+                        icon = <Icon type="info" style={{ fontSize: 16, color: '#f50' }} />;
+                    }
+                    return <div>
+                        <Link to={{ pathname: '/buildDetail', search: params({ parentId: value._id }) }}
+                            style={{ color: value.buildResult === "SUCCESS" ? "#2cbe4e" : (value.buildResult === "FAILURE" ? "#f50" : "#DAA520") }}>Build #{value.buildNum}  <Tooltip title={value.buildResult}>{icon}</Tooltip>
+                        </Link>
+
+                        <br />{renderPublishName(value)}
+                    </div>
+                }
+                return null;
+            };
+
+            const renderBuild = (value) => {
+                if (value && value.buildNum) {
+                    let result = value.buildResult;
+                    if (value.tests && value.tests.length > 0) {
+                        result = value.tests[0].testResult;
+                        if (value.tests[0]._id) {
+                            return <div>
+                                <Link to={{ pathname: '/output/test', search: params({ id: value.tests[0]._id }) }}
+                                    style={{ color: result === "PASSED" ? "#2cbe4e" : (result === "FAILED" ? "#f50" : "#DAA520") }}>
+                                    Build #{value.buildNum}
+                                </Link>
+                            </div>;
+                        }
+                    } else {
+                        return <div>
+                            <Link to={{ pathname: '/buildDetail', search: params({ parentId: value._id }) }}
+                                style={{ color: result === "SUCCESS" ? "#2cbe4e" : (result === "FAILURE" ? "#f50" : "#DAA520") }}> Build #{value.buildNum}
+                            </Link>
+                        </div>;
+                    }
+                }
+                return null;
+            };
+
+            const renderJenkinsLinks = ({ buildName, buildNum, buildUrl, url }) => {
+                // Temporarily support BlueOcean link under folders
+                let blueOcean;
+                if (`${url}`.includes("/jobs") || `${url}`.includes("/build-scripts")) {
+                    let urls = url.split("/job/");
+                    let basicUrl = urls.shift();
+                    urls.push(buildName);
+                    let newUrl = urls.join("%2F");
+                    blueOcean = `${basicUrl}/blue/organizations/jenkins/${newUrl}/detail/${buildName}/${buildNum}`;
+                } else {
+                    blueOcean = `${url}/blue/organizations/jenkins/${buildName}/detail/${buildName}/${buildNum}`;
+                }
+                return <div><a href={buildUrl} target="_blank" rel="noopener noreferrer">{buildName} #{buildNum}</a><br /><a href={blueOcean} target="_blank" rel="noopener noreferrer">Blue Ocean</a></div>;
+            };
+
+            const renderTotals = (value, row, index) => {
+                if (!value) return <div>N/A</div>;
+                const { failed = 0, passed = 0, disabled = 0, skipped = 0, total = 0 } = value;
+                const buildResult = row.build.buildResult;
+                const id = row.build._id;
+                return <>
+                    <Link to={{ pathname: '/resultSummary', search: params({ parentId: id }) }}
+                        style={{ color: buildResult === "SUCCESS" ? "#2cbe4e" : (buildResult === "FAILURE" ? "#f50" : "#DAA520") }}>Grid
+                    </Link>
+                    <div>
+                        <BuildLink id={id} label="Failed: " link={failed} testSummaryResult="failed" buildNameRegex="^Test.*" />
+                        <BuildLink id={id} label="Passed: " link={passed} testSummaryResult="passed" buildNameRegex="^Test.*" />
+                        <BuildLink id={id} label="Disabled: " link={disabled} testSummaryResult="disabled" buildNameRegex="^Test.*" />
+                        <BuildLink id={id} label="Skipped: " link={skipped} testSummaryResult="skipped" buildNameRegex="^Test.*" />
+                        <BuildLink id={id} label="Total: " link={total} testSummaryResult="total" buildNameRegex="^Test.*" />
+                    </div>
+                </>;
+            };
+
+            const renderBuildResults = (value) => {
+                return <div>
+                    <BuildLink id={value._id} link="Failed Builds " buildResult="!SUCCESS" />
+                </div>;
+            };
+
+            const renderPublishName = ({ buildParams = [] }) => {
+                const param = buildParams.find(param => param.name === "overridePublishName");
+                if (param)
+                    return param.value;
+            };
+
+            const columns = [{
+                title: 'Build',
+                dataIndex: 'build',
+                key: 'build',
+                render: type === "Perf" ? renderBuild : renderFvTestBuild,
+                sorter: (a, b) => {
+                    return a.key.localeCompare(b.key);
+                }
+            }, {
+                title: 'Build Results',
+                dataIndex: 'build',
+                key: 'buildResults',
+                render: renderBuildResults,
+            }, {
+                title: 'Test Results',
+                dataIndex: 'totals',
+                key: 'testResults',
+                render: renderTotals,
+            }, {
+                title: 'StartBy',
+                dataIndex: 'startBy',
+                key: 'startBy',
+                sorter: (a, b) => {
+                    return a.startBy.localeCompare(b.startBy);
+                }
+            }, {
+                title: 'Jenkins Link',
+                dataIndex: 'jenkins',
+                key: 'jenkins',
+                render: renderJenkinsLinks,
+            }, {
+                title: 'Date',
+                dataIndex: 'date',
+                key: 'date',
+                sorter: (a, b) => {
+                    return a.date.localeCompare(b.date);
+                }
+            }];
+
+            return <Table
+                columns={columns}
+                dataSource={buildInfo}
+                title={() => <div><b>{buildName}</b> in server {url}</div>}
+                pagination={{ pageSize, onChange: this.onChange }}
+            />;
+        } else {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
As we monitor more builds and keep longer history, the first landing
page becomes slow. The reason is that we are trying to prepare all data
regardless it will show up or not. In the landing page, due to table
pagination we only show the latest 5 builds from each pipeline. The rest
does not need to be queried until the user clicks on the next page.

This PR updates the logic to simplify TopLevelBuilds.jsx. We separate it
to contain React components. Each table/pipeline is one component. Each
component keep tracks its own pagination. Query is based on the table
pagination.

Signed-off-by: lanxia <lan_xia@ca.ibm.com>