### PR TITLE
Add jck in the Grid view

### DIFF
--- a/test-result-summary-client/src/Build/Summary/ResultSummary.jsx
+++ b/test-result-summary-client/src/Build/Summary/ResultSummary.jsx
@@ -10,7 +10,7 @@ import TestBreadcrumb from '../TestBreadcrumb';
 const hcvalues = {
     hcjdkImpls: ["j9", "hs", "Upstream"],
     hclevels: ["sanity", "extended", "special"],
-    hcgroups: ["functional", "openjdk", "system", "external", "perf"]
+    hcgroups: ["functional", "openjdk", "system", "external", "perf", "jck"]
 }
 
 export default class ResultSummary extends Component {


### PR DESCRIPTION
All jck builds that are triggered in nightly will show up in the Grid view

Issue: #191

Signed-off-by: lanxia <lan_xia@ca.ibm.com>