### PR TITLE
Fixed bugs in perfCompare, Parser and aggregateInfo

### DIFF
--- a/TestResultSummaryService/parsers/Parser.js
+++ b/TestResultSummaryService/parsers/Parser.js
@@ -7,7 +7,7 @@ class Parser {
 
     exactJavaVersion(output) {
         const javaVersionRegex = /(((openjdk|java) version[\s\S]*?)(JCL.*)|((openjdk|java) version[\s\S]*?)(Server VM.*))/;
-        const javaBuildDateRegex = /-(20[0-9][0-9][0-9][0-9][0-9][0-9])/;
+        const javaBuildDateRegex = /\s([0-9]{4})(0[1-9]|1[012])(0[1-9]|[12][0-9]|3[01])/;
         const sdkResourceRegex = /.*?SDK_RESOURCE\=(.*)[\r\n]/;
         let curRegexResult = null;
         let javaVersion, jdkDate, sdkResource;
@@ -21,7 +21,7 @@ class Parser {
         curRegexResult = null;
         // parse jdk date from javaVersion
         if ( ( curRegexResult = javaBuildDateRegex.exec( javaVersion ) ) !== null ) {
-            jdkDate = curRegexResult[1];
+            jdkDate = curRegexResult[0];
         }
         return { javaVersion, jdkDate, sdkResource };
     }

--- a/TestResultSummaryService/perf/DataManagerAggregate.js
+++ b/TestResultSummaryService/perf/DataManagerAggregate.js
@@ -71,18 +71,18 @@ class DataManagerAggregate {
                     metrics
                 });
             });
-            //identify if the aggregateinfo is valid, save duplicate checks in front end usage.
-            if (!(Array.isArray(aggregateInfo) && aggregateInfo.length > 0)) {
-                validAggregateInfo = false;
-            } else {
-                for(let {benchmarkName, benchmarkVariant, metrics} of aggregateInfo){
-                    if(!(benchmarkName && benchmarkVariant && Array.isArray(metrics) && metrics.length > 0)){
-                        validAggregateInfo = false;
-                    } else {
-                        for(let{name, statValues} of metrics) {
-                            if (!(name && Object.keys(statValues).length > 0 && statValues.validIterations > 0)) {
-                                validAggregateInfo = false;
-                            }
+        }
+        //identify if the aggregateinfo is valid, save duplicate checks in front end usage.
+        if (!(Array.isArray(aggregateInfo) && aggregateInfo.length > 0)) {
+            validAggregateInfo = false;
+        } else {
+            for(let {benchmarkName, benchmarkVariant, metrics} of aggregateInfo){
+                if(!(benchmarkName && benchmarkVariant && Array.isArray(metrics) && metrics.length > 0)){
+                    validAggregateInfo = false;
+                } else {
+                    for(let{name, statValues} of metrics) {
+                        if (!(name && Object.keys(statValues).length > 0 && statValues.validIterations > 0)) {
+                            validAggregateInfo = false;
                         }
                     }
                 }

--- a/test-result-summary-client/src/PerfCompare/PerfCompare.jsx
+++ b/test-result-summary-client/src/PerfCompare/PerfCompare.jsx
@@ -47,7 +47,6 @@ export default class PerfCompare extends Component {
         	inputURL[url] = urlData[url];
         }
         await this.setState({inputURL: inputURL});
-        this.handleParseInputURL();
     }
 
     handleChange(event) {
@@ -601,9 +600,9 @@ export default class PerfCompare extends Component {
             let generatedTables = this.state.allVariantData.map( (x,i) => 
                 <div key={i}>
                     <h3>
-                        Benchmark: {x.benchmarkName}
+                        Benchmark: {x.benchmark}
                         <Divider type="vertical" />
-                        Variant: {x.benchmarkVariant}
+                        Variant: {x.variant}
                     </h3>
 
                     Baseline JDK Date: {x.baselineJdkDate} 


### PR DESCRIPTION
https://github.com/AdoptOpenJDK/openjdk-test-tools/issues/201

- fixed displaying bugs in benchmarkName/variant showing in perfCompare
- fixed jdkDate regex bug in Parser.js
- fixed bug of `validAggregateInfo` in DataManagerAggregate

Signed-off-by: sophiaxu0424 <xuminghong0424@gmail.com>