### PR TITLE
CleanUp: updated getParserProps.js to remove duplicate logic

### DIFF
--- a/TestResultSummaryService/routes/getBenchmarkMetricProps.js
+++ b/TestResultSummaryService/routes/getBenchmarkMetricProps.js
@@ -1,0 +1,10 @@
+const benchmarkMetric = require( '../parsers/BenchmarkMetric');
+const utils =require( '../parsers/Utils');
+module.exports = async ( req, res ) => {
+    const { benchmarkName } = req.query;
+    const key = utils.getBenchmarkParserKey(benchmarkName);
+    if (key) {
+        res.json(benchmarkMetric[key]["metrics"]);
+    }
+    res.json();
+}

--- a/TestResultSummaryService/routes/getParserProps.js
+++ b/TestResultSummaryService/routes/getParserProps.js
@@ -1,4 +1,0 @@
-const benchmarkMetric = require( '../parsers/BenchmarkMetric');
-module.exports = async ( req, res ) => {
-    res.json({benchmarkMetric});
-}

--- a/TestResultSummaryService/routes/index.js
+++ b/TestResultSummaryService/routes/index.js
@@ -10,7 +10,7 @@ app.get( '/deleteUnusedOutput', wrap( require( "./deleteUnusedOutput" ) ) );
 app.get( '/getAllChildBuilds', wrap( require( "./getAllChildBuilds" ) ) );
 app.get( '/getAllTestsWithHistory', wrap( require( "./getAllTestsWithHistory" ) ) );
 app.get( '/getAuditLogs', wrap( require( "./getAuditLogs" ) ) );
-app.get( '/getParserProps', wrap ( require ("./getParserProps") )) ;
+app.get( '/getBenchmarkMetricProps', wrap ( require ("./getBenchmarkMetricProps") )) ;
 app.get( '/getBuildHistory', wrap( require( "./getBuildHistory" ) ) );
 app.get( '/getBuildList', wrap( require( "./getBuildList" ) ) );
 app.get( '/getChildBuilds', wrap( require( "./getChildBuilds" ) ) );

--- a/test-result-summary-client/src/utils/perf.js
+++ b/test-result-summary-client/src/utils/perf.js
@@ -1,22 +1,9 @@
 
-export const getParserProps = async () => {
-    let parserProps = await fetch( `/api/getParserProps`, {
+export const getBenchmarkMetricProps = async (benchmarkName) => {
+    let parserProps = await fetch( `/api/getBenchmarkMetricProps?benchmarkName=${benchmarkName}`, {
             method: 'get'
         }
     );
     parserProps = await parserProps.json();
-    return parserProps;  
-}
-
-export function getMetricProps(parserProps,benchmarkName,curMetric) {
-    let benchmarkMetric = parserProps['benchmarkMetric'];
-    try {
-        for(let key of Object.keys(benchmarkMetric)){
-            if(benchmarkName.includes(key)){
-                return benchmarkMetric[key]["metrics"][curMetric]
-            }
-        }
-    } catch (benchmarkInfoErr) {
-        return "";
-    }
+    return parserProps;
 }


### PR DESCRIPTION
Issue: https://github.com/AdoptOpenJDK/openjdk-test-tools/issues/211

- Updated getParserPropes.js to receve benchmarkName, so it would return the metrics directly as needed
- Updated perfCompare and TabularView accordingly
- Updated utils/perf.js file

Signed-off-by: sophiaxu0424 <xuminghong0424@gmail.com>