### PR TITLE
Remove url.parse

### DIFF
--- a/TestResultSummaryService/LogStream.js
+++ b/TestResultSummaryService/LogStream.js
@@ -7,8 +7,7 @@ class LogStream {
     constructor(options) {
         this.credentails = ArgParser.getConfig();
         const build = options.build || 'lastBuild';
-        const urlParsed = url.parse(options.baseUrl + '/job/' + options.job + '/' + build + '/logText/progressiveText');
-        this.url = addCredential(this.credentails, options.baseUrl) + urlParsed.path;
+        this.url = addCredential(this.credentails, options.baseUrl) + '/job/' + options.job + '/' + build + '/logText/progressiveText';
     }
     async next(startPtr) {
         try {
@@ -23,7 +22,7 @@ class LogStream {
             }
         }
         catch (e) {
-            logger.warn("LogStreamError: ", e);
+            logger.warn("LogStreamError: ", this.url, e);
         }
     }
 }


### PR DESCRIPTION
url.parse is not needed in streaming as we can directly concatenate the
url


Signed-off-by: lanxia <lan_xia@ca.ibm.com>