### PR TITLE
add testName validation in test parser

### DIFF
--- a/TestResultSummaryService/parsers/Test.js
+++ b/TestResultSummaryService/parsers/Test.js
@@ -1,7 +1,7 @@
 const Parser = require('./Parser');
 const regexRunningTest = /.*?Running test (.*?) \.\.\.\r?/;
-const regexFinishTime = /.*?Finish Time\: .* Epoch Time \(ms\)\: (.*).*/;
-const regexStartTime = /.*?Start Time\: .* Epoch Time \(ms\)\: (.*).*/;
+const regexFinishTime = /(.*?) Finish Time\: .* Epoch Time \(ms\)\: (\d+).*/;
+const regexStartTime = /(.*?) Start Time\: .* Epoch Time \(ms\)\: (\d+).*/;
 const TestBenchmarkParser = require( `./TestBenchmarkParser`);
 const Utils = require(`./Utils`);
 
@@ -61,7 +61,7 @@ class Test extends Parser {
                 testResultRegex = new RegExp(testName + "_(.*)\r?");
             }
             if ((m = line.match(regexStartTime)) !== null) {
-                startTime = m[1];
+                startTime = (m[1].includes(testName) && m[2] > 0)? m[2] : null;
             }
             if (testResultRegex && ((m = testResultRegex.exec(line)) !== null)) {
                 testResult = m[1];
@@ -69,14 +69,14 @@ class Test extends Parser {
             if (testName) {
                 testStr += line + "\n";
                 if ((m = line.match(regexFinishTime)) !== null) {
+                    finishTime = (m[1].includes(testName) && m[2] > 0)? m[2] : null;
 
-                    finishTime = m[1];
                     results.push({
                         testName,
                         testOutput: testStr,
                         testResult,
                         testData: null,
-                        duration: finishTime - startTime,
+                        duration: (startTime && finishTime && finishTime - startTime > 0) ? finishTime - startTime : null,
                         startTime
                     });
                     testName = null;


### PR DESCRIPTION
This draft PR has my own testing (console.log etc) and I will delete them when convert to the formal PR. 
Here is how I test my changes: 
1. test located at [backend.js](https://github.com/OscarQQ/openjdk-test-tools/blob/e8486d92ca748cf512e01b500486abae95871d73/TestResultSummaryService/backend.js#L9) It will load a test parser and parse a predefined string. Duration is assigned only when testName == startTestName == finishTestName. When I change any of the test names, duration is assigned to null (expected)

Sample output:
```
testname!    jck_custom_0
startTestName   jck_custom_1
starttime    1590098570256
finishTestName   jck_custom_0
finishTime    1590098577444
duration        null
```

2. console.log() in [test parser](https://github.com/OscarQQ/openjdk-test-tools/blob/e8486d92ca748cf512e01b500486abae95871d73/TestResultSummaryService/parsers/Test.js#L61). here is some output when reloading the database: 
```
testname!    UpgradeModPathTest_Jarred_0
startTestName   UpgradeModPathTest_Jarred_0
starttime    1590162376109
finishTestName   UpgradeModPathTest_Jarred_0
finishTime    1590162382080
duration        5971
testname!    UpgradeModPathTest_JarredImg_0
startTestName   UpgradeModPathTest_JarredImg_0
starttime    1590162382102
finishTestName   UpgradeModPathTest_JarredImg_0
finishTime    1590162387825
duration        5723
......
```
duration is not affected and displayed correctly on my localhost Grid(same as the data on production server)

I didn't use \d+ when extracting start/finish time because we currently use (.*) and it works fine

fixes: #245
Signed-off-by: Yixin Qian <Yixin.Qian@ibm.com>