### PR TITLE
fix the link for parallel builds

### DIFF
--- a/test-result-summary-client/src/Build/Summary/ResultSummary.jsx
+++ b/test-result-summary-client/src/Build/Summary/ResultSummary.jsx
@@ -77,7 +77,7 @@ export default class ResultSummary extends Component {
                     if (build.hasChildren) {
                         buildMap[platform][jdkVersion][jdkImpl][level][group].buildResult = build.buildResult;
                         buildMap[platform][jdkVersion][jdkImpl][level][group].buildUrl = build.buildUrl;
-                        buildMap[platform][jdkVersion][jdkImpl][level][group]._id = build._id;
+                        buildMap[platform][jdkVersion][jdkImpl][level][group].buildId = build._id;
                         buildMap[platform][jdkVersion][jdkImpl][level][group].hasChildren = build.hasChildren;
 
                     } else if (build.testSummary) {


### PR DESCRIPTION
console.log(groups[group]) at [ResultGrid](https://github.com/OscarQQ/openjdk-test-tools/blob/831591802510f7ecd50a5fb771e5ea0e975392cb/test-result-summary-client/src/Build/Summary/ResultGrid.jsx#L57) 
```
buildId: "5ecc4cb43b161d1310c235da"
buildResult: "SUCCESS"
buildUrl: "https://ci.eclipse.org/openj9/job/Test_openjdk8_j9_special.system_ppc64_aix_Nightly/882/"
hasChildren: true
testSummary: {total: 366, executed: 147, passed: 147, failed: 0, disabled: 27, …}
_id: "5ecc4b9c3b161d1310c22729"
__proto__: Object
```
we are interested in _id, not buildId, when redirect to parallel builds

localhost seems working, I can see the expected page

fixes: #247
Signed-off-by: Yixin Qian <Yixin.Qian@ibm.com>