### PR TITLE
enhance java version extraction

### DIFF
--- a/TestResultSummaryService/parsers/Parser.js
+++ b/TestResultSummaryService/parsers/Parser.js
@@ -8,7 +8,7 @@ class Parser {
     static canParse() { return false; }
 
     exactJavaVersion(output) {
-        const javaVersionRegex = /(((openjdk|java) version[\s\S]*?)(JCL\s.*)|((openjdk|java) version[\s\S]*?)(Server VM.*)|((openjdk|java) version[\s\S]*?)(Zero VM\s.*))/;
+        const javaVersionRegex = /=JAVA VERSION OUTPUT BEGIN=\n([\s\S]*?)\n.*=JAVA VERSION OUTPUT END=/;
         const javaBuildDateRegex = /\s([0-9]{4})(0[1-9]|1[012])(0[1-9]|[12][0-9]|3[01])/;
         const sdkResourceRegex = /.*?SDK_RESOURCE\=(.*)[\r\n]/;
         let curRegexResult = null;


### PR DESCRIPTION
add Java Version tags in jenkins console output
1. =JAVA VERSION OUTPUT BEGIN=
2. =JAVA VERSION OUTPUT END=
update regex

related: https://github.com/AdoptOpenJDK/openjdk-tests/pull/1840
related issue: https://github.com/AdoptOpenJDK/openjdk-test-tools/issues/269
enhancement of: https://github.com/AdoptOpenJDK/openjdk-test-tools/pull/270

Signed-off-by: Yixin Qian <Yixin.Qian@ibm.com>