### PR TITLE
Add keepforever option

### DIFF
--- a/TestResultSummaryService/BuildMonitor.js
+++ b/TestResultSummaryService/BuildMonitor.js
@@ -49,6 +49,7 @@ class BuildMonitor {
                     status = "Streaming";
                     logger.info(`Set build ${url} ${buildName} ${buildNum} status to Streaming `);
                 }
+                const keepForever = false;
                 const buildData = {
                     url,
                     buildName,
@@ -57,6 +58,7 @@ class BuildMonitor {
                     buildResult: allBuilds[i].result ? allBuilds[i].result : null,
                     timestamp: allBuilds[i].timestamp ? allBuilds[i].timestamp : null,
                     type: type === "FVT" ? "Test" : type,
+                    keepForever,
                     status,
                 };
                 const _id = await new DataManager().createBuild(buildData);
@@ -66,6 +68,7 @@ class BuildMonitor {
                     url,
                     buildName,
                     buildNum,
+                    keepForever,
                     status,
                 });
             } else {
@@ -105,8 +108,7 @@ class BuildMonitor {
         const { buildName, url } = this.getBuildInfo(buildUrl);
         // keep only limited builds in DB and delete old builds
         const testResults = new TestResultsDB();
-        const allBuildsInDB = await testResults.getData({ url, buildName }).sort({ buildNum: 1 }).toArray();
-
+        const allBuildsInDB = await testResults.getData({ url, buildName, keepForever: { $ne: true } }).sort({ buildNum: 1 }).toArray();
         if (allBuildsInDB && allBuildsInDB.length > numBuildsToKeep) {
             const endIndex = Math.max(0, allBuildsInDB.length - numBuildsToKeep);
             await Promise.all(allBuildsInDB.slice(0, endIndex).map(async (build) => {

--- a/TestResultSummaryService/routes/index.js
+++ b/TestResultSummaryService/routes/index.js
@@ -35,7 +35,9 @@ app.get( '/getTestPerPlatform', wrap( require( "./getTestPerPlatform" ) ) );
 app.get( '/getTopLevelBuildNames', wrap( require( "./getTopLevelBuildNames" ) ) );
 app.get( '/getTotals', wrap( require( "./getTotals" ) ) );
 app.get( '/populateDB', wrap( require( "./populateDB" ) ) );
+
 app.get( '/updateComments', wrap( require( "./updateComments" ) ) );
+app.get( '/updateKeepForever', wrap( require( "./updateKeepForever" ) ) );
 
 // jwt
 app.post( '/auth/register', wrap( require( "./jwt/register" ) ) );

--- a/TestResultSummaryService/routes/updateKeepForever.js
+++ b/TestResultSummaryService/routes/updateKeepForever.js
@@ -1,0 +1,17 @@
+const { TestResultsDB, ObjectID } = require('../Database');
+
+/*
+* updateKeepForever API updates keepForever based on _id
+*/
+module.exports = async (req, res) => {
+    const { _id, keepForever } = req.query;
+    if (_id && keepForever) {
+        const keepForeverVal = (keepForever === 'true');
+        const db = new TestResultsDB();
+        const criteria = { _id: new ObjectID(_id) };
+        await db.update(criteria, { $set: { keepForever: keepForeverVal } }, { upsert: false });
+        res.send({ error: false });
+    } else {
+        res.json({ error: true });
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}


### PR DESCRIPTION
Once the keepforever checkbox is selected for a build, this build will
not be removed even if we reach max # builds to keep.

Ideally, this keepforever option should only be available for admin.
This should be updated once we have authentication added.

Resolves: https://github.com/AdoptOpenJDK/openjdk-test-tools/issues/288

Signed-off-by: lanxia <lan_xia@ca.ibm.com>