### PR TITLE
add grinder rerun link in git new issue

### DIFF
--- a/TestResultSummaryService/parsers/Parser.js
+++ b/TestResultSummaryService/parsers/Parser.js
@@ -66,6 +66,16 @@ class Parser {
         return machine;
     }
 
+    extractRerunLink (output) {
+        let m;
+        let rerunLink = null;
+        const rerunLinkRegex = /Rerun in Grinder: (.*?)\n/;
+        if ( ( m = rerunLinkRegex.exec( output ) ) !== null ) {
+            rerunLink = m[1];
+        }
+        return rerunLink;
+    }
+
     extractTestSummary( output ) {
         let m;
         let total = 0;

--- a/TestResultSummaryService/parsers/Test.js
+++ b/TestResultSummaryService/parsers/Test.js
@@ -25,6 +25,7 @@ class Test extends Parser {
         tests.testSummary = this.extractTestSummary(output);
         tests.startBy = this.extractStartedBy(output);
         tests.artifactory = this.extractArtifact(output);
+        tests.rerunLink = this.extractRerunLink(output);
         return tests;
     }
 

--- a/test-result-summary-client/src/Build/AllTestsInfo.jsx
+++ b/test-result-summary-client/src/Build/AllTestsInfo.jsx
@@ -88,7 +88,8 @@ export default class Build extends Component {
                     buildId: buildData[0]._id,
                     buildUrl: buildData[0].buildUrl,
                     buildTimeStamp: buildData[0].timestamp,
-                    javaVersion: buildData[0].javaVersion
+                    javaVersion: buildData[0].javaVersion,
+                    rerunLink: buildData[0].rerunLink
                 };
                 ret.action = {
                     testId: test._id,

--- a/test-result-summary-client/src/Build/GitNewIssue.jsx
+++ b/test-result-summary-client/src/Build/GitNewIssue.jsx
@@ -24,7 +24,7 @@ export default class GitNewissue extends Component {
 
     async updateData() {
         const { testId, testName, duration, buildId, buildName,
-            buildUrl, machine, buildTimeStamp, javaVersion, testResult } = getParams(this.props.location.search);
+            buildUrl, machine, buildTimeStamp, javaVersion, testResult, rerunLink } = getParams(this.props.location.search);
 
         let firstSeenFailure = null;
         let failCount = 0;
@@ -98,7 +98,8 @@ export default class GitNewissue extends Component {
                 + `Jenkins Build URL: ${firstSeenFailure.buildUrl}${nl}${nl}`
                 + failMachineUrlBody
             ))
-            + (gitDiffLinksBody ? `${nl}**Git Diff of first seen failure and last success**${nl}` + gitDiffLinksBody : ``);
+            + (gitDiffLinksBody ? `${nl}**Git Diff of first seen failure and last success**${nl}` + gitDiffLinksBody : ``)
+            + (rerunLink ? `${nl}[Rerun in Grinder](${rerunLink})` : ``);
 
         this.setState({
             body,
@@ -124,7 +125,7 @@ export default class GitNewissue extends Component {
                         </a>
                     </Tooltip>
                 }>
-                    <pre>{body}</pre>
+                    <pre className="card-body">{body}</pre>
                 </Card>
             </div>
         );

--- a/test-result-summary-client/src/Build/table.css
+++ b/test-result-summary-client/src/Build/table.css
@@ -4,3 +4,8 @@
 	background: #fff;
 	box-shadow: 0 1px 6px rgba(0, 0, 0, .2);
 }
+
+.card-body {
+	word-break: break-all;
+	white-space: pre-wrap;
+}


### PR DESCRIPTION
- extract rerun link from Jenkins console output
- show link to grinder rerun when open the git new issue tab
related: https://github.com/AdoptOpenJDK/openjdk-test-tools/issues/258

Signed-off-by: OscrQQ <Yixin.Qian@ibm.com>