### PR TITLE
capture failure console output in git new issue

### DIFF
--- a/TestResultSummaryService/routes/getErrorInOutput.js
+++ b/TestResultSummaryService/routes/getErrorInOutput.js
@@ -1,0 +1,33 @@
+const { OutputDB, ObjectID } = require( '../Database' );
+const { removeTimestamp } = require( './utils/removeTimestamp' );
+const matchStrings = [
+    "Unhandled exception",
+];
+
+module.exports = async ( req, res ) => {
+    if (req.query.id) {
+        req.query.id = new ObjectID( req.query.id );
+        const outputDB = new OutputDB();
+        const result = await outputDB.getData( req.query.id ).toArray();
+
+        if (result && result.length > 0 && result[0].output){
+            const output = removeTimestamp(result[0].output);
+
+            // build regex expression based on error scenarios
+            const matchRegex = new RegExp(matchStrings.join("|"));
+        
+            let lastLines = [];
+            // search console output backward
+            for (let line of output.split("\n").reverse()) {
+                lastLines.push(line);
+                if (line.match(matchRegex)) {
+                    // return 10 lines of console output of error message
+                    return res.send( {
+                        output: lastLines.reverse().slice(0, 10).join('\n')
+                    } );
+                }
+            }
+        }
+    }
+    res.send( { output: null } );
+}

--- a/TestResultSummaryService/routes/index.js
+++ b/TestResultSummaryService/routes/index.js
@@ -17,6 +17,7 @@ app.get( '/getBuildList', wrap( require( "./getBuildList" ) ) );
 app.get( '/getChildBuilds', wrap( require( "./getChildBuilds" ) ) );
 app.get( '/getDashboardBuildInfo', wrap( require( "./getDashboardBuildInfo" ) ) );
 app.get( '/getData', wrap( require( "./getData" ) ) );
+app.get( '/getErrorInOutput', wrap( require( "./getErrorInOutput" ) ) );
 app.get( '/getHistoryPerTest', wrap( require( "./getHistoryPerTest" ) ) );
 app.get( '/getJenkins', wrap( require( "./getJenkins" ) ) );
 app.get( '/getLastBuildInfo', wrap( require( "./getLastBuildInfo" ) ) );


### PR DESCRIPTION
- create a new parser to get 10 lines of failure output
- fix the bug when rerunLink is undefined
- related: #258 

Signed-off-by: OscarQQ <Yixin.Qian@ibm.com>