### PR TITLE
Enhance getTestAvgDuration API

### DIFF
--- a/TestResultSummaryService/Database.js
+++ b/TestResultSummaryService/Database.js
@@ -177,10 +177,23 @@ class Database {
         if (level) buildNameRegex = `${buildNameRegex}${level}..*`;
         if (group) buildNameRegex = `${buildNameRegex}${group}_.*`;
         if (platform) buildNameRegex = `${buildNameRegex}${platform}.*`;
+
+        // remove * at the end of buildNameRegex
+        buildNameRegex = buildNameRegex.replace(/\*$/, '');
+
+        // when calculate test average duration, exclude Personal builds
+        buildNameRegex = buildNameRegex + `(?:(?!Personal).)*$`;
+
         const buildResultRegex = buildResult || 'SUCCESS|UNSTABLE';
 
         matchQuery.buildName = { $regex: buildNameRegex };
         matchQuery.buildResult = { $regex: buildResultRegex };
+        matchQuery.hasChildren = false;
+        matchQuery.tests = {
+            "$exists": true, 
+            "$ne": null
+        };
+
         // the aggregate order is important. Please change with caution
         const aggregateQuery = [
             { $match: matchQuery },


### PR DESCRIPTION
When calculating test avg duration,
- exclude personal builds. Personal builds are not stable.
- only count the test builds that do not have child builds. In parallel
testing, parent test builds do not run tests.
- only count the test builds that contain tests


Signed-off-by: lanxia <lan_xia@ca.ibm.com>