### PR TITLE
Process large output

### DIFF
--- a/TestResultSummaryService/BuildProcessor.js
+++ b/TestResultSummaryService/BuildProcessor.js
@@ -135,13 +135,15 @@ class BuildProcessor {
             task.status = "CurrentBuildDone";
 
             const output = await jenkinsInfo.getBuildOutput(task.url, task.buildName, task.buildNum);
-            task.output = output;
-            await new DataManager().updateBuildWithOutput(task);
-
-            await new AuditLogsDB().insertAuditLogs({
-                action: "[processBuild]: updateBuildWithOutput",
-                ...task
-            });
+            if (output) {
+                task.output = output;
+                await new DataManager().updateBuildWithOutput(task);
+    
+                await new AuditLogsDB().insertAuditLogs({
+                    action: "[processBuild]: updateBuildWithOutput",
+                    ...task
+                });
+            }
         } else if (!task.timestamp || !task.buildUrl) {
             await new DataManager().updateBuild({
                 _id: task._id,

--- a/TestResultSummaryService/LogStream.js
+++ b/TestResultSummaryService/LogStream.js
@@ -11,18 +11,45 @@ class LogStream {
     }
     async next(startPtr) {
         try {
+            logger.debug(`LogStream: next(): url: ${this.url} startPtr: ${startPtr}`);
             const response = await got.get(this.url, {
                 followRedirect: true,
                 query: { start: startPtr },
+                timeout : 4 * 60 * 1000,
             });
             if (response.body.length === 0) {
                 return "";
             } else {
                 return response.body;
             }
+        } catch (e) {
+            logger.debug("LogStreamError: next(): ", this.url, e);
+            // if return code is 404, it means this build no longer exists.
+            if (e.toString().includes("Response code 404 (Not Found)")) {
+                return `${this.url} no longer exists`;
+            }
         }
-        catch (e) {
-            logger.warn("LogStreamError: ", this.url, e);
+    }
+
+    // check the response size using http head request
+    async getSize() {
+        try {
+            logger.debug(`LogStream: getSize(): url: ${this.url}`);
+            // set timeout to 4 mins
+            const timeout = 4 * 60 * 1000;
+            const { headers } = await got.head(this.url, { timeout });
+            if (headers && headers["x-text-size"]) {
+                logger.debug(`LogStream: getSize(): size: ${headers["x-text-size"]}`);
+                return headers["x-text-size"];
+            } else {
+                return -1;
+            }
+        } catch (e) {
+            logger.debug("LogStreamError: getSize(): ", this.url, e);
+            // if return code is 404, it means this build no longer exists.
+            if (e.toString().includes("Response code 404 (Not Found)")) {
+                return 0;
+            }
         }
     }
 }

--- a/TestResultSummaryService/package.json
+++ b/TestResultSummaryService/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified! Configure in package.json\" && exit 1",
     "startFrontend": "nodemon frontend.js --configFile=./trssConf.json",
-    "startBackend": "nodemon backend.js --configFile=./trssConf.json",
+    "startBackend": "nodemon --max-old-space-size=6144 backend.js --configFile=./trssConf.json",
     "start": "npm-run-all --parallel startFrontend startBackend"
   },
   "repository": "",

--- a/TestResultSummaryService/parsers/ParentBuild.js
+++ b/TestResultSummaryService/parsers/ParentBuild.js
@@ -7,7 +7,11 @@ const regexBuilds = /(\[(.*?)\])?Starting building: (.*?) ?#(\d*)/g;
 
 class ParentBuild extends Parser {
     static canParse( buildName, output ) {
-        return output.includes( "Starting building:" );
+        if (output) {
+            return output.includes( "Starting building:" );
+        } else {
+            return false;
+        }
     }
     parse( output ) {
         let openJ9Sha = null;

--- a/TestResultSummaryService/parsers/Test.js
+++ b/TestResultSummaryService/parsers/Test.js
@@ -9,12 +9,17 @@ const Utils = require(`./Utils`);
 
 class Test extends Parser {
     static canParse(buildName, output) {
-        if (buildName.indexOf("Test-") === 0) {
-            return true;
+        if (output) {
+            if (buildName.indexOf("Test-") === 0) {
+                return true;
+            } else {
+                return output.includes("Running test ");
+            }
         } else {
-            return output.includes("Running test ");
+            return false;
         }
     }
+
     async parse(output) {
         const tests = await this.extract(output);
         const {javaVersion, jdkDate, sdkResource} = this.exactJavaVersion(output);


### PR DESCRIPTION
- Due to 1G string limit, we cannot store ouptut > 1G. Using http head
request to get the output size in getSize(). If the size > 1G, only
process the last 0.7G. This is a temporary fix, so that TRSS can proceed
and continue processing other builds.

- instead of using Jenkins nodejs API, we change to use `got` to query.
This will allow us to control the query precisely.

- increase regular query timeout from 2secs to 30secs and reduce the
retry from 5 times to 3 times for Jenkins nodejs APIs. It is better to
retry less often with longer timeout

- increase node max memory to 6G


Signed-off-by: lanxia <lan_xia@ca.ibm.com>