### PR TITLE
Only process the output size < limit

### DIFF
--- a/TestResultSummaryService/DataManager.js
+++ b/TestResultSummaryService/DataManager.js
@@ -89,7 +89,7 @@ class DataManager {
     }
 
     async updateBuild( data ) {
-        logger.verbose( "updateBuild", data );
+        logger.verbose("updateBuild", data.buildName, data.buildNum);
         const { _id, buildName, ...newData } = data;
         const criteria = { _id: new ObjectID( _id ) };
         const testResults = new TestResultsDB();

--- a/TestResultSummaryService/EventHandler.js
+++ b/TestResultSummaryService/EventHandler.js
@@ -36,6 +36,8 @@ class EventHandler {
                             ...task
                         });
                     }
+                    logger.debug( "EventHandler: processBuild() is waiting for 2 secs before processing the next build" );
+                    await Promise.delay( 2 * 1000 );
                 }
             } catch ( e ) {
                 logger.error( "Exception in database query: ", e );
@@ -45,7 +47,7 @@ class EventHandler {
                 });
             }
             const elapsedTime = elapsed[Math.min( count, elapsed.length - 1 )];
-            logger.verbose( `processBuild is waiting for ${elapsedTime} sec` );
+            logger.verbose( `EventHandler: processBuild() is waiting for ${elapsedTime} secs before checking DB for builds != Done` );
             await Promise.delay( elapsedTime * 1000 );
         }
     }
@@ -81,7 +83,7 @@ class EventHandler {
                 });
             }
             const elapsedTime = 15 * 60;
-            logger.verbose( `monitorBuild is waiting for ${elapsedTime} sec` );
+            logger.verbose( `EventHandler: monitorBuild() is waiting for ${elapsedTime} secs` );
             await Promise.delay( elapsedTime * 1000 );
         } 
     }

--- a/TestResultSummaryService/LogStream.js
+++ b/TestResultSummaryService/LogStream.js
@@ -10,46 +10,30 @@ class LogStream {
         this.url = addCredential(this.credentails, options.baseUrl) + '/job/' + options.job + '/' + build + '/logText/progressiveText';
     }
     async next(startPtr) {
-        try {
-            logger.debug(`LogStream: next(): url: ${this.url} startPtr: ${startPtr}`);
-            const response = await got.get(this.url, {
-                followRedirect: true,
-                query: { start: startPtr },
-                timeout : 4 * 60 * 1000,
-            });
-            if (response.body.length === 0) {
-                return "";
-            } else {
-                return response.body;
-            }
-        } catch (e) {
-            logger.debug("LogStreamError: next(): ", this.url, e);
-            // if return code is 404, it means this build no longer exists.
-            if (e.toString().includes("Response code 404 (Not Found)")) {
-                return `${this.url} no longer exists`;
-            }
+        logger.debug(`LogStream: next(): [CIServerRequest] url: ${this.url} startPtr: ${startPtr}`);
+        const response = await got.get(this.url, {
+            followRedirect: true,
+            query: { start: startPtr },
+            timeout: 4 * 60 * 1000,
+        });
+        if (response.body.length === 0) {
+            return "";
+        } else {
+            return response.body;
         }
     }
 
     // check the response size using http head request
     async getSize() {
-        try {
-            logger.debug(`LogStream: getSize(): url: ${this.url}`);
-            // set timeout to 4 mins
-            const timeout = 4 * 60 * 1000;
-            const { headers } = await got.head(this.url, { timeout });
-            if (headers && headers["x-text-size"]) {
-                logger.debug(`LogStream: getSize(): size: ${headers["x-text-size"]}`);
-                return headers["x-text-size"];
-            } else {
-                return -1;
-            }
-        } catch (e) {
-            logger.debug("LogStreamError: getSize(): ", this.url, e);
-            // if return code is 404, it means this build no longer exists.
-            if (e.toString().includes("Response code 404 (Not Found)")) {
-                return 0;
-            }
+        logger.debug(`LogStream: getSize(): [CIServerRequest] url: ${this.url}`);
+        // set timeout to 4 mins
+        const timeout = 4 * 60 * 1000;
+        const { headers } = await got.head(this.url, { timeout });
+        if (headers && headers["x-text-size"]) {
+            logger.debug(`LogStream: getSize(): size: ${headers["x-text-size"]}`);
+            return headers["x-text-size"];
+        } else {
+            return -1;
         }
     }
 }

--- a/TestResultSummaryService/backend.js
+++ b/TestResultSummaryService/backend.js
@@ -6,6 +6,7 @@ ArgParser.parse();
 
 const EventHandler = require( './EventHandler' );
 
+// running processBuild() and monitorBuild() in parallel
 setTimeout(() => {
     const handler = new EventHandler();
     handler.processBuild();

--- a/TestResultSummaryService/package.json
+++ b/TestResultSummaryService/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified! Configure in package.json\" && exit 1",
     "startFrontend": "nodemon frontend.js --configFile=./trssConf.json",
-    "startBackend": "nodemon --max-old-space-size=6144 backend.js --configFile=./trssConf.json",
+    "startBackend": "nodemon --max-old-space-size=4096 backend.js --configFile=./trssConf.json",
     "start": "npm-run-all --parallel startFrontend startBackend"
   },
   "repository": "",

--- a/TestResultSummaryService/plugins/DataManagerPerf.js
+++ b/TestResultSummaryService/plugins/DataManagerPerf.js
@@ -3,7 +3,7 @@ const { logger } = require( '../Utils' );
 
 
 module.exports.onBuildDone = async (task, { testResultsDB, logger }) => {
-    logger.debug("onBuildDone", task.buildName);
+    logger.debug("DataManagerPerf: onBuildDone:", task.buildName, task.buildNum);
     if ( task.type === "Perf" ) {
         if ( !task.aggregateInfo ) {
             let jdkDate, javaVersion, nodeRunDate, nodeVersion;

--- a/TestResultSummaryService/plugins/examplePlugin.js
+++ b/TestResultSummaryService/plugins/examplePlugin.js
@@ -1,7 +1,7 @@
 // This is an example plugin
 
 module.exports.onBuildDone = async (task, { testResultsDB, logger }) => {
-    logger.debug("onBuildDone", task.buildName);
+    logger.debug("examplePlugins: onBuildDone:", task.buildName, task.buildNum);
 
     // Example code for querying testResultsDB
     // const result = await testResultsDB.getData({ parentId: task._id, status: { $ne: "Done" } }).toArray();

--- a/TestResultSummaryService/routes/getJenkins.js
+++ b/TestResultSummaryService/routes/getJenkins.js
@@ -5,8 +5,12 @@ module.exports = async (req, res) => {
     const { url, buildName, buildNum } = req.query;
     if (req.query.buildNum) req.query.buildNum = parseInt(req.query.buildNum, 10);
     const jenkinsInfo = new JenkinsInfo();
-    const output = await jenkinsInfo.getBuildOutput(url, buildName, buildNum);
-    const filename = "./output_" + Math.random();
-    fs.writeFileSync(filename, output);
-    res.send({ result: filename });
+    try {
+        const output = await jenkinsInfo.getBuildOutput(url, buildName, buildNum);
+        const filename = "./output_" + Math.random();
+        fs.writeFileSync(filename, output);
+        res.send({ result: filename });
+    } catch (e) {
+        res.send({ result: e.toString() });
+    }
 }

--- a/test-result-summary-client/src/Build/AlertMsg.jsx
+++ b/test-result-summary-client/src/Build/AlertMsg.jsx
@@ -1,0 +1,10 @@
+import React, { Component } from 'react';
+import { Alert } from 'antd';
+
+export default class AlertMsg extends Component {
+    render() {
+        const { error } = this.props;
+        if (!error) return null;
+        return <Alert message="Error" description={error} type="error" showIcon />
+    }
+}

--- a/test-result-summary-client/src/Build/Output/Output.jsx
+++ b/test-result-summary-client/src/Build/Output/Output.jsx
@@ -4,6 +4,7 @@ import { Col, Row, Switch } from 'antd';
 import TestBreadcrumb from '../TestBreadcrumb';
 import classnames from 'classnames';
 import Artifacts from './Artifacts';
+import AlertMsg from '../AlertMsg';
 import "./output.css";
 
 export default class Output extends Component {
@@ -61,9 +62,8 @@ export default class Output extends Component {
                     output: result.output,
                     result: info.buildResult
                 };
-            } else {
-                data = { error: true };
             }
+            data.error = info.error ? `${info.buildUrl}: ${info.error}` : "";
         }
 
         this.setState( { data, outputType } );
@@ -106,10 +106,9 @@ export default class Output extends Component {
     render() {
         const { data } = this.state;
         if ( data ) {
-            if ( data.error ) {
-                return "Cannot find output!";
+            if (data.error) {
+                return <AlertMsg error={data.error} />
             }
-
             return <div className="test-wrapper">
                 <TestBreadcrumb buildId={data.buildId} testId={data.testId} testName={data.name} />
                 {this.renderContent()}


### PR DESCRIPTION
Process a large output (700M+) may cause OOM in CI server and/or TRSS.
Update the logic to only process the output < limit. If the output > limit, 
record the error and display in UI. The limit is set to 50M for now as the 
regular build output is ~3M. We can adjust the limit as needed.

This PR also includes the following changes:
- remove try catch in the lower level (LogStream) and the exception will
be caught at the higher level (BuildProcessor), so that we can store the
exception into DB
- add AlertMsg in UI
- add short sleep (2 secs) in between processing each build to avoid overloading
 CI server. And 5 secs sleep after getting the output size.
- add log for each CI server request with [CIServerRequest] (for
debugging)
- reduce max memory from 6G to 4G in dev env (to match with
production env)

Signed-off-by: lanxia <lan_xia@ca.ibm.com>