### PR TITLE
change default OpenJ9 to AdoptOpenJDK in buildStatus widget

### DIFF
--- a/test-result-summary-client/src/Dashboard/Widgets/BuildStatus/BuildStatus.jsx
+++ b/test-result-summary-client/src/Dashboard/Widgets/BuildStatus/BuildStatus.jsx
@@ -66,7 +66,7 @@ export default class BuildStatus extends Component {
     static Setting = BuildStatusSetting;
     static defaultSize = { w: 4, h: 4 }
     static defaultSettings = {
-        serverSelected: "OpenJ9"
+        serverSelected: "AdoptOpenJDK"
     }
 
     state = {


### PR DESCRIPTION
fixes: #335
Signed-off-by: OscarQQ <Yixin.Qian@ibm.com>