### PR TITLE
Improvement in addCredential()

### DIFF
--- a/TestResultSummaryService/Utils.js
+++ b/TestResultSummaryService/Utils.js
@@ -14,12 +14,14 @@ const logger = new ( winston.Logger )( {
 
 const addCredential = (credentails, url) => {
     if (credentails) {
-        if (credentails.hasOwnProperty(url)) {
-            const user = encodeURIComponent(credentails[url].user);
-            const password = encodeURIComponent(credentails[url].password);
-            const tokens = url.split("://");
-            if (tokens.length == 2 && user && password) {
-                url = `${tokens[0]}://${user}:${password}@${tokens[1]}`;
+        for (const k in credentails) {
+            if (url.startsWith(k)) {
+                const user = encodeURIComponent(credentails[k].user);
+                const password = encodeURIComponent(credentails[k].password);
+                const tokens = url.split("://");
+                if (tokens.length == 2 && user && password) {
+                    return `${tokens[0]}://${user}:${password}@${tokens[1]}`;
+                }
             }
         }
     }

--- a/TestResultSummaryService/routes/getLogStream.js
+++ b/TestResultSummaryService/routes/getLogStream.js
@@ -1,0 +1,16 @@
+const LogStream = require('../LogStream');
+
+module.exports = async (req, res) => {
+    const { url, buildName, buildNum } = req.query;
+    try {
+        const logStream = new LogStream({
+            baseUrl: url,
+            job: buildName,
+            build: parseInt(buildNum, 10),
+        });
+        const output = await logStream.next(0);
+        res.send({ result: output });
+    } catch (e) {
+        res.send({ result: e.toString() });
+    }
+}

--- a/TestResultSummaryService/routes/index.js
+++ b/TestResultSummaryService/routes/index.js
@@ -22,6 +22,7 @@ app.get( '/getErrorInOutput', wrap( require( "./getErrorInOutput" ) ) );
 app.get( '/getHistoryPerTest', wrap( require( "./getHistoryPerTest" ) ) );
 app.get( '/getJenkins', wrap( require( "./getJenkins" ) ) );
 app.get( '/getLastBuildInfo', wrap( require( "./getLastBuildInfo" ) ) );
+app.get( '/getLogStream', wrap( require( "./getLogStream" ) ) );
 app.get( '/getOutputById', wrap( require( "./getOutputById" ) ) );
 app.get( '/getOutputByTestInfo', wrap( require( "./getOutputByTestInfo" ) ) );
 app.get( '/getTestAvgDuration', wrap( require( "./getTestAvgDuration" ) ) );


### PR DESCRIPTION
- the original logic only searches for exactly matched URL.
The base URL may not be exactly the same once we have folder structure on Jenkins.
Updated the logic to do startWith()
- Add getLogStream API for debugging purpose

Signed-off-by: lanxia <lan_xia@ca.ibm.com>